### PR TITLE
Fix(subtitles): Resolve issues with "Translate" options and download …

### DIFF
--- a/a4kSubtitles/tests/test_download.py
+++ b/a4kSubtitles/tests/test_download.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+# Assuming download function is in a4kSubtitles.download
+from a4kSubtitles.download import download
+
+class TestDownloadFunction(unittest.TestCase):
+
+    @patch('a4kSubtitles.download.__copy_sub_local') # Patching this as it's not relevant to the core logic
+    @patch('a4kSubtitles.download.__postprocess')
+    @patch('a4kSubtitles.download.__extract_zip')
+    @patch('a4kSubtitles.download.__extract_gzip')
+    @patch('a4kSubtitles.download.__download')
+    # Keep filename simple for __insert_lang_code_in_filename, it returns filename.lang_code by default
+    # Let's mock it to return a predictable filename, e.g., original_filename.lang_code
+    @patch('a4kSubtitles.download.__insert_lang_code_in_filename', side_effect=lambda core, filename, lang_code: f"{filename.rsplit('.', 1)[0]}.{lang_code}.{filename.rsplit('.', 1)[1]}" if '.' in filename else f"{filename}.{lang_code}")
+    def test_download_with_save_callback(self, mock_insert_fn, mock_download_internal, mock_extract_gzip, mock_extract_zip, mock_postprocess, mock_copy_sub_local):
+        core_mock = MagicMock()
+        core_mock.utils.temp_dir = '/tmp/temp_subtitles'
+        core_mock.utils.slugify_filename.side_effect = lambda x: x # Keep filename as is
+        core_mock.utils.get_lang_id.return_value = 'eng' # For 'en' language
+        core_mock.os.path.join.side_effect = lambda *args: '/'.join(args) # Simple path join mock
+        
+        # Mocks for initial setup functions
+        core_mock.shutil.rmtree = MagicMock()
+        core_mock.kodi.xbmcvfs.mkdirs = MagicMock()
+        core_mock.api_mode_enabled = False # Assuming it's not API mode for this test
+
+        mock_save_callback = MagicMock(return_value=True)
+        
+        mock_service_instance = MagicMock()
+        # The request built by build_download_request should contain the save_callback
+        mock_service_instance.build_download_request.return_value = {
+            'save_callback': mock_save_callback,
+            # other request parts if necessary for the download function to proceed
+            'url': 'http://dummyurl.com/sub.zip' # A dummy URL, though not used by save_callback path
+        }
+        
+        core_mock.services = {'test_service': mock_service_instance}
+
+        params = {
+            'service_name': 'test_service',
+            'action_args': {
+                'lang': 'en', # This will be processed by get_lang_id to 'eng'
+                'filename': 'My.Movie.Title.srt',
+                # Any other args needed by build_download_request or download function
+            }
+        }
+
+        # Call the actual download function
+        download(core_mock, params)
+
+        # Assertions
+        mock_save_callback.assert_called_once()
+        
+        # Determine the expected filename after __insert_lang_code_in_filename and slugify
+        # Based on mocked __insert_lang_code_in_filename: "My.Movie.Title.eng.srt"
+        # Based on mocked slugify_filename: "My.Movie.Title.eng.srt" (no change)
+        expected_processed_filename = "My.Movie.Title.eng.srt"
+        expected_srt_path = '/tmp/temp_subtitles/' + expected_processed_filename
+        
+        args, _ = mock_save_callback.call_args
+        self.assertEqual(args[0], expected_srt_path)
+
+        mock_download_internal.assert_not_called()
+        mock_extract_gzip.assert_not_called()
+        mock_extract_zip.assert_not_called()
+        
+        # Check that __postprocess was called with the srt_path and lang_code ('eng')
+        mock_postprocess.assert_called_once_with(core_mock, expected_srt_path, 'eng')
+        mock_copy_sub_local.assert_not_called() # Should not be called if api_mode_enabled is False
+
+if __name__ == '__main__':
+    unittest.main()

--- a/a4kSubtitles/tests/test_search.py
+++ b/a4kSubtitles/tests/test_search.py
@@ -1,0 +1,100 @@
+import unittest
+from unittest.mock import Mock, MagicMock
+
+import unittest
+from unittest.mock import Mock, MagicMock
+
+import unittest
+from unittest.mock import Mock, MagicMock
+
+import unittest
+from unittest.mock import Mock, MagicMock
+
+# Import the function using an alias
+from a4kSubtitles.search import __sanitize_results as sanitize_results_to_test
+
+class TestSanitizeResults(unittest.TestCase):
+    def test_sanitize_preserves_translate_options(self):
+        # 1. Mock core and meta objects
+        mock_core = MagicMock()
+        mock_core.utils.unquote = lambda x: x  # Mock unquote to return input
+
+        mock_meta = Mock()
+
+        # 2. Construct sample results data
+        results_data = [
+            {
+                'service_name': 'subtitlecat',
+                'lang': 'de',
+                'name': 'Movie Title German',
+                'action_args': {
+                    'url': '',
+                    'filename': 'Movie.Title.srt',
+                    'needs_client_side_translation': True,
+                    'original_srt_url': 'http://subtitlecat.com/original/german.srt',
+                    'lang': 'de'
+                }
+            },
+            {
+                'service_name': 'subtitlecat',
+                'lang': 'zh',
+                'name': 'Movie Title Chinese',
+                'action_args': {
+                    'url': '',
+                    'filename': 'Movie.Title.srt',
+                    'needs_client_side_translation': True,
+                    'original_srt_url': 'http://subtitlecat.com/original/chinese.srt',
+                    'lang': 'zh'
+                }
+            },
+            {
+                'service_name': 'subtitlecat',
+                'lang': 'fr',
+                'name': 'Movie Title French',
+                'action_args': {
+                    'url': '', # No direct URL
+                    'filename': 'Movie.Title.srt',
+                    'method_type': 'SHARED_TRANSLATION_CONTENT', # Uses detail_url
+                    'detail_url': 'http://subtitlecat.com/details/french.html',
+                    'lang': 'fr'
+                }
+            },
+            {
+                'service_name': 'opensubtitles',
+                'lang': 'en',
+                'name': 'Movie Title English OpenSubtitles',
+                'action_args': {
+                    'url': 'http://opensubtitles.org/subs/english.srt', # Direct URL
+                    'filename': 'Movie.Title.OS.srt',
+                    'lang': 'en'
+                }
+            }
+        ]
+
+        # 3. Call the aliased function
+        sanitized_results = sanitize_results_to_test(mock_core, mock_meta, results_data)
+
+        # 4. Assertions
+        self.assertEqual(len(sanitized_results), 4, "Should preserve all unique items")
+
+        # Check for presence of specific translate options
+        found_german_subtitlecat = any(
+            r['service_name'] == 'subtitlecat' and r['lang'] == 'de' for r in sanitized_results
+        )
+        found_chinese_subtitlecat = any(
+            r['service_name'] == 'subtitlecat' and r['lang'] == 'zh' for r in sanitized_results
+        )
+        found_french_subtitlecat = any(
+            r['service_name'] == 'subtitlecat' and r['lang'] == 'fr' for r in sanitized_results
+        )
+        found_english_opensubtitles = any(
+            r['service_name'] == 'opensubtitles' and r['lang'] == 'en' for r in sanitized_results
+        )
+
+        self.assertTrue(found_german_subtitlecat, "German Subtitlecat translate option missing")
+        self.assertTrue(found_chinese_subtitlecat, "Chinese Subtitlecat translate option missing")
+        self.assertTrue(found_french_subtitlecat, "French Subtitlecat translate option (SHARED_TRANSLATION_CONTENT) missing")
+        self.assertTrue(found_english_opensubtitles, "English OpenSubtitles option missing")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…errors

This commit addresses two main issues:

1.  **Missing "Translate" Options (search.py):**
    - I modified `__sanitize_results` in `a4kSubtitles/search.py` to generate more unique keys for subtitle entries, especially those without direct download URLs (e.g., "Translate" options from Subtitlecat).
    - The new key considers service name, language, filename, and provider-specific identifiers (like `original_srt_url` or `detail_url` for Subtitlecat).
    - This ensures that all available "Translate" options for different languages are displayed in the search results instead of being overwritten.
    - I added unit tests to verify that multiple "Translate" options are preserved.

2.  **"ZipManager: not a zip file!" Error (download.py):**
    - I updated the `download` function in `a4kSubtitles/download.py` to correctly handle downloads that use a `save_callback` (e.g., client-side translations from Subtitlecat).
    - If a `save_callback` is present, it's now responsible for saving the final SRT file directly to the correct path.
    - The logic that attempts to extract an archive (zip or gzip) is bypassed for these cases, preventing the "ZipManager: not a zip file!" error.
    - I added unit tests to confirm that `save_callback` is used and archive extraction is skipped when appropriate.

The changes include corresponding unit tests for both modifications to ensure correctness and prevent regressions.