### PR TITLE
feat: Enable Subtitlecat upload feature via settings

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -93,3 +93,7 @@ msgstr ""
 msgctxt "#33303"
 msgid "API Key"
 msgstr ""
+
+msgctxt "#33209"
+msgid "Automatically upload translated subtitles to Subtitlecat"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -18,6 +18,7 @@
         <setting id="opensubtitles.enabled" label="33201" type="bool" default="false"/>
         <setting id="podnadpisi.enabled"    label="33203" type="bool" default="false"/>
         <setting id="subtitlecat.enabled"   label="33208" type="bool" default="true"/> 
+        <setting id="subtitlecat_upload_translations" label="33209" type="bool" default="true"/>
         <setting id="subdl.enabled"         label="33205" type="bool" default="false"/>
         <setting id="subsource.enabled"     label="33207" type="bool" default="false"/>
     </category>


### PR DESCRIPTION
Adds a new setting to control the automatic upload of client-side translated subtitles to Subtitlecat.com. This feature was already present in the subtitlecat.py service script but was not exposed in the addon's settings.

The new setting 'subtitlecat_upload_translations' is:
- Added to resources/settings.xml.
- Labeled as "Automatically upload translated subtitles to Subtitlecat" (ID 33209 in strings.po).
- Enabled by default.

This allows you to utilize the existing functionality to share your client-translated subtitles back to the Subtitlecat community.