### PR TITLE
Fix Addon mock initialization

### DIFF
--- a/a4kSubtitles/lib/kodi_mock.py
+++ b/a4kSubtitles/lib/kodi_mock.py
@@ -64,7 +64,8 @@ def __get_addon_info(name):
         return os.path.join(os.path.dirname(__file__), '../../tmp')
 __addon.getAddonInfo = __get_addon_info
 __addon.getSetting = lambda _: ''
-xbmcaddon.Addon = lambda _: __addon
+# Allow Addon() to be called with or without parameters
+xbmcaddon.Addon = lambda *_, **__: __addon
 
 # xbmcplugin
 xbmcplugin = lambda: None


### PR DESCRIPTION
## Summary
- allow calling `xbmcaddon.Addon()` with or without an ID in the Kodi test mock

## Testing
- `pytest tests/test_api.py::test_api_mocking -q`
- `pytest tests/test_service.py::test_service_start_when_video_playing -q`


------
https://chatgpt.com/codex/tasks/task_e_6841539a8fb8832f95ce03b92f0d12c0