### PR TITLE
Fix subtitle byte reading and add test

### DIFF
--- a/a4kSubtitles/download.py
+++ b/a4kSubtitles/download.py
@@ -94,7 +94,10 @@ def __insert_lang_code_in_filename(core, filename, lang_code):
 
 def __postprocess(core, filepath, lang_code):
     try:
-        with open(filepath, 'rb', encoding=core.utils.default_encoding) as f:
+        # Read the subtitle bytes in binary mode. The file's encoding will be
+        # detected or assumed later when decoding ``text_bytes`` so we avoid
+        # passing an ``encoding`` parameter here.
+        with open(filepath, 'rb') as f:
             text_bytes = f.read()
 
         if core.kodi.get_bool_setting('general.use_chardet'):

--- a/a4kSubtitles/tests/test_postprocess.py
+++ b/a4kSubtitles/tests/test_postprocess.py
@@ -1,0 +1,25 @@
+import os
+from unittest.mock import MagicMock
+from a4kSubtitles import download
+
+
+def test_postprocess_binary_read(tmp_path):
+    sample_text = "Hello subtitle"
+    p = tmp_path / "sample.srt"
+    p.write_bytes(sample_text.encode('utf-8'))
+
+    core_mock = MagicMock()
+    core_mock.os = os
+    core_mock.kodi.get_bool_setting.return_value = False
+
+    core_mock.utils.default_encoding = 'utf-8'
+    core_mock.utils.base_encoding = 'raw_unicode_escape'
+    core_mock.utils.py3 = True
+    core_mock.utils.code_pages = {}
+    core_mock.utils.cp1251_garbled = 'xyz'
+    core_mock.utils.koi8r_garbled = 'abc'
+    core_mock.utils.cleanup_subtitles.side_effect = lambda core, text: text
+
+    download.__postprocess(core_mock, str(p), 'eng')
+
+    assert p.read_text(encoding='utf-8') == sample_text


### PR DESCRIPTION
## Summary
- open subtitle files without specifying encoding in binary mode
- test __postprocess to ensure bytes are read without encoding

## Testing
- `PYTHONPATH=$PWD pytest -q a4kSubtitles/tests/test_postprocess.py`
- `flake8 .` *(fails: E501, E261, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684154e79a64832fa3060fe12aa3fc08