### PR TITLE
Move Subtitlecat upload option to General settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ This section covers the main behavior of the addon.
 *   **Prefer Forced Subtitles (ID: `general.prefer_forced`):**
     *   **What it does:** If enabled, the addon will try to prioritize "forced" subtitles. Forced subtitles are used to translate dialogue in a foreign language when the main audio track is in your preferred language (e.g., alien speech in a sci-fi movie). This preference is active when "Auto-select subtitle if only one result" is true or "Auto Download First Result Silently" is true.
     *   **Default:** True (Enabled).
+*   **Upload Translated Subtitles to Subtitlecat (ID: `subtitlecat_upload_translations`):**
+    *   **What it does:** When PolyglotSubs-Kodi requests an on-demand translation from Subtitlecat, enabling this option allows the addon to share the translated subtitle back with Subtitlecat so other users can benefit. Disable it if you prefer the translation to remain private.
+    *   **Default:** True (Enabled - contributes back to Subtitlecat).
 *   **Enable/Disable Embedded Subtitles:**
     *   **Note:** PolyglotSubs-Kodi primarily focuses on downloading external subtitle files. The handling of embedded subtitles (those already within your video file) is usually controlled by Kodi's main player settings, not this addon's settings specifically. Check under **Settings -> Player -> Language -> Enable parsing for closed captions / Teletext**.
 
@@ -100,9 +103,6 @@ This section allows you to enable or disable individual subtitle providers. Poly
 *   **OpenSubtitles (ID: `opensubtitles.enabled`):** Default: False (Disabled). *Requires account details in the "Accounts" section.*
 *   **Podnadpisi.NET (ID: `podnadpisi.enabled`):** Default: False (Disabled)
 *   **Subtitlecat.com (ID: `subtitlecat.enabled`):** Default: True (Enabled)
-    *   **Also for Subtitlecat - Upload translated subtitles (ID: `subtitlecat_upload_translations`):**
-        *   **What it does:** When PolyglotSubs-Kodi requests an on-demand translation from Subtitlecat, this setting (if enabled) allows the addon to indicate to Subtitlecat that the translated result can be shared and made available to other Subtitlecat users. This helps improve the Subtitlecat database over time. Disabling this means translations are for your use only.
-        *   **Default:** True (Enabled - contributes back to Subtitlecat).
 *   **SubDL (ID: `subdl.enabled`):** Default: False (Disabled). *May require API key in the "Accounts" section.*
 *   **SubSource (ID: `subsource.enabled`):** Default: False (Disabled)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,7 @@
         <setting id="general.auto_select"    label="33106" type="bool"   default="true"  />
         <setting id="general.prefer_sdh"     label="33107" type="bool"   default="false" enable="eq(-1,true)" />
         <setting id="general.prefer_forced"  label="33108" type="bool"   default="true"  enable="eq(-1,false)+eq(-2,true)" />
+        <setting id="subtitlecat_upload_translations" label="33209" type="bool" default="true"/>
     </category>
     <!-- Services -->
     <category label="33002">
@@ -17,8 +18,7 @@
         <setting id="bsplayer.enabled"      label="33202" type="bool" default="false"/>
         <setting id="opensubtitles.enabled" label="33201" type="bool" default="false"/>
         <setting id="podnadpisi.enabled"    label="33203" type="bool" default="false"/>
-        <setting id="subtitlecat.enabled"   label="33208" type="bool" default="true"/> 
-        <setting id="subtitlecat_upload_translations" label="33209" type="bool" default="true"/>
+        <setting id="subtitlecat.enabled"   label="33208" type="bool" default="true"/>
         <setting id="subdl.enabled"         label="33205" type="bool" default="false"/>
         <setting id="subsource.enabled"     label="33207" type="bool" default="false"/>
     </category>


### PR DESCRIPTION
## Summary
- add `subtitlecat_upload_translations` to the General category
- remove the option from the Services section
- document the new option location in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841677f2110832fbac31c161dd8feeb