### PR TITLE
Add tests for A4kSubtitles API

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,64 +1,73 @@
 # -*- coding: utf-8 -*-
 
 from .common import pytest, api
-import pytest as real_pytest
 
-real_pytest.skip("Outdated API mocking test", allow_module_level=True)
-
-def test_api_mocking():
-    def get_error_msg(e):
-        return str(e.value).replace('\'', '')
-
-    with pytest.raises(ImportError) as e:
-        api.A4kSubtitlesApi()
-    assert get_error_msg(e) == "No module named xbmc"
-
-    with pytest.raises(ImportError) as e:
-        api.A4kSubtitlesApi({'xbmc': True})
-    assert get_error_msg(e) == "No module named xbmcaddon"
-
-    with pytest.raises(ImportError) as e:
-        api.A4kSubtitlesApi({'xbmc': True, 'xbmcaddon': True})
-    assert get_error_msg(e) == "No module named xbmcplugin"
-
-    with pytest.raises(ImportError) as e:
-        api.A4kSubtitlesApi({'xbmc': True, 'xbmcaddon': True, 'xbmcplugin': True})
-    assert get_error_msg(e) == "No module named xbmcgui"
-
-    with pytest.raises(ImportError) as e:
-        api.A4kSubtitlesApi({'xbmc': True, 'xbmcaddon': True, 'xbmcplugin': True, 'xbmcgui': True})
-    assert get_error_msg(e) == "No module named xbmcvfs"
-
-    api.A4kSubtitlesApi({'xbmc': True, 'xbmcaddon': True, 'xbmcplugin': True, 'xbmcgui': True, 'xbmcvfs': True})
-    api.A4kSubtitlesApi({'kodi': True})
 
 def test_auto_load_enabled():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4k_api = api.A4kSubtitlesApi({'kodi': True})
 
-    settings = {
+    assert a4k_api.auto_load_enabled({
         'general.auto_search': 'true',
         'general.auto_download': 'true',
-    }
-    auto_load_enabled = a4ksubtitles_api.auto_load_enabled(settings)
-    assert auto_load_enabled is True
+    }) is True
 
-    settings = {
+    assert a4k_api.auto_load_enabled({
         'general.auto_search': 'false',
         'general.auto_download': 'true',
-    }
-    auto_load_enabled = a4ksubtitles_api.auto_load_enabled(settings)
-    assert auto_load_enabled is False
+    }) is False
 
-    settings = {
+    assert a4k_api.auto_load_enabled({
         'general.auto_search': 'true',
         'general.auto_download': 'false',
-    }
-    auto_load_enabled = a4ksubtitles_api.auto_load_enabled(settings)
-    assert auto_load_enabled is False
+    }) is False
 
-    settings = {
+    assert a4k_api.auto_load_enabled({
         'general.auto_search': 'false',
         'general.auto_download': 'false',
+    }) is False
+
+
+def test_search_uses_mocked_settings_and_video_meta():
+    a4k_api = api.A4kSubtitlesApi({'kodi': True})
+
+    def fake_search(core_module, params):
+        return {
+            'title': core_module.kodi.xbmc.getInfoLabel('VideoPlayer.OriginalTitle'),
+            'setting': core_module.kodi.addon.getSetting('general.test'),
+            'params': params,
+        }
+
+    default_search = a4k_api.core.search
+    a4k_api.core.search = fake_search
+    try:
+        result = a4k_api.search({'q': 'query'}, settings={'general.test': 'value'}, video_meta={'title': 'Movie'})
+    finally:
+        a4k_api.core.search = default_search
+
+    assert result == {
+        'title': 'Movie',
+        'setting': 'value',
+        'params': {'q': 'query'},
     }
-    auto_load_enabled = a4ksubtitles_api.auto_load_enabled(settings)
-    assert auto_load_enabled is False
+
+
+def test_download_uses_mocked_settings():
+    a4k_api = api.A4kSubtitlesApi({'kodi': True})
+
+    def fake_download(core_module, params):
+        return {
+            'setting': core_module.kodi.addon.getSetting('download.path'),
+            'params': params,
+        }
+
+    default_download = a4k_api.core.download
+    a4k_api.core.download = fake_download
+    try:
+        result = a4k_api.download({'id': 1}, settings={'download.path': '/tmp'})
+    finally:
+        a4k_api.core.download = default_download
+
+    assert result == {
+        'setting': '/tmp',
+        'params': {'id': 1},
+    }


### PR DESCRIPTION
## Summary
- add tests covering A4kSubtitlesApi auto-load logic and use of mocked settings/video metadata

## Testing
- `pytest`
- `flake8 tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68938adbaaf0832f865d3b1e175219ba