### PR TITLE
Fix pre-commit isort hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.12.0
+    rev: v5.10.1
     hooks:
       - id: isort


### PR DESCRIPTION
## Summary
- adjust isort pre-commit hook to a valid tagged release

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68939ec1d6e8832f8ddf784e46a53f43