### PR TITLE
chore: exclude third-party libraries from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: ^a4kSubtitles/lib/third_party/
 repos:
   - repo: https://github.com/psf/black
     rev: 24.4.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,11 @@ We welcome pull requests for bug fixes and improvements.
     The project uses `.flake8` for linting.
 
 #### Running Linters and Tests
+*   **Pre-commit:** Run the pre-commit hooks to format and lint code:
+    ```bash
+    pre-commit run --all-files
+    ```
+    The configuration excludes bundled third-party modules in `a4kSubtitles/lib/third_party/`.
 *   **Linting:** Ensure your changes pass linting before submitting:
     ```bash
     flake8 .
@@ -48,7 +53,8 @@ We welcome pull requests for bug fixes and improvements.
 
 #### Coding Standards
 *   Please follow the existing code style.
-*   Run `flake8` to check for linting errors before submitting a pull request. Configuration is in `.flake8`.
+*   Run `pre-commit run --all-files` to check for formatting and linting issues. Configuration is in `.pre-commit-config.yaml` and `.flake8`.
+*   Bundled third-party code lives in `a4kSubtitles/lib/third_party/`. These files are intentionally excluded from pre-commit hooks and should not be edited or linted.
 *   Ensure your code is well-commented, especially in complex or non-obvious parts.
 
 #### Submitting Pull Requests

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This addon, like the original, is licensed under the MIT License. See the [LICEN
 
 ## Contributing
 
-We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to report issues, suggest features, and submit pull requests.
+We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to report issues, suggest features, and submit pull requests. Note that our pre-commit configuration excludes bundled third-party modules under `a4kSubtitles/lib/third_party/`, so those files are intentionally not edited or linted.
 
 ## Icon
 


### PR DESCRIPTION
## Summary
- ignore bundled third-party modules in pre-commit
- document pre-commit exclusion for bundled third-party code

## Testing
- `pre-commit run --all-files` *(fails: black reformatted files, flake8 F811 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68946fb6b598832f924013573c0a851b