### PR TITLE
Use pre-commit for linting in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           pip install beautifulsoup4
       - name: Lint
         run: |
-          flake8 --exit-zero
+          pre-commit run --all-files
       - name: Test
         run: |
           pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: ^a4kSubtitles/lib/third_party/
 repos:
   - repo: https://github.com/psf/black
     rev: 24.4.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,14 @@ We welcome pull requests for bug fixes and improvements.
 4.  **Dependencies for Linting/Testing:**
     Install development dependencies (linters, test runners):
     ```bash
-    pip install -r requirements-dev.txt 
+    pip install -r requirements-dev.txt
     ```
-    The project uses `.flake8` for linting.
+    This installs [pre-commit](https://pre-commit.com), which manages linting for the project.
 
 #### Running Linters and Tests
 *   **Linting:** Ensure your changes pass linting before submitting:
     ```bash
-    flake8 .
+    pre-commit run --all-files
     ```
 *   **Tests:** Run the automated test suite:
     ```bash
@@ -48,7 +48,7 @@ We welcome pull requests for bug fixes and improvements.
 
 #### Coding Standards
 *   Please follow the existing code style.
-*   Run `flake8` to check for linting errors before submitting a pull request. Configuration is in `.flake8`.
+*   Run `pre-commit run --all-files` to check for linting errors before submitting a pull request. Configuration is in `.pre-commit-config.yaml`.
 *   Ensure your code is well-commented, especially in complex or non-obvious parts.
 
 #### Submitting Pull Requests

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This addon, like the original, is licensed under the MIT License. See the [LICEN
 
 ## Contributing
 
-We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to report issues, suggest features, and submit pull requests.
+We welcome contributions! Install the development dependencies with `pip install -r requirements-dev.txt` and run `pre-commit run --all-files` to lint your code before submitting. Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to report issues, suggest features, and submit pull requests.
 
 ## Icon
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ beautifulsoup4
 pytest
 flake8
 coverage
+pre-commit


### PR DESCRIPTION
## Summary
- run `pre-commit` instead of `flake8` in CI tests
- install `pre-commit` dependencies and exclude vendored libraries from checks
- document `pre-commit run --all-files` workflow for contributors

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68946fb932a0832fb0baa2f1ab053acb