### PR TITLE
Add opt-in marker for integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ We welcome pull requests for bug fixes and improvements.
     pytest
     ```
     The tests mock Kodi's environment and can be run from the project root after installing `requirements-dev.txt`.
+    Integration tests are skipped by default. Include them with:
+    ```bash
+    pytest --run-integration
+    ```
 
 #### Coding Standards
 *   Please follow the existing code style.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ The general usage for searching and selecting subtitles remains consistent with 
 
 This addon, like the original, is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.
 
+## Testing
+
+Run unit tests with:
+
+```bash
+pytest
+```
+
+Integration tests are skipped by default. Include them with:
+
+```bash
+pytest --run-integration
+```
+
 ## Contributing
 
 We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to report issues, suggest features, and submit pull requests. Note that our pre-commit configuration excludes bundled third-party modules under `a4kSubtitles/lib/third_party/`, so those files are intentionally not edited or linted.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = -ra
 python_files = tests/*.py
+markers =
+    integration: mark tests that require external services and are skipped unless --run-integration is given

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="run integration tests",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-integration"):
+        return
+    skip_integration = pytest.mark.skip(reason="need --run-integration option to run")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/tests/test_opt_integration_marker.py
+++ b/tests/test_opt_integration_marker.py
@@ -1,0 +1,44 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ("pytester",)
+
+
+def test_integration_marker_respected(pytester):
+    # copy project conftest to pytester directory to include --run-integration flag
+    conftest_path = Path(__file__).with_name("conftest.py")
+    pytester.makeconftest(conftest_path.read_text())
+
+    # register the integration marker to avoid warnings
+    pytester.makeini(
+        textwrap.dedent(
+            """
+            [pytest]
+            markers =
+                integration: mark tests that require external services and are skipped unless --run-integration is given
+            """
+        )
+    )
+
+    # create a sample test marked as integration
+    pytester.makepyfile(
+        textwrap.dedent(
+            """
+            import pytest
+
+            @pytest.mark.integration
+            def test_example():
+                assert True
+            """
+        )
+    )
+
+    # By default, integration tests are skipped
+    result = pytester.runpytest()
+    result.assert_outcomes(skipped=1)
+
+    # With --run-integration, the test is executed and passes
+    result = pytester.runpytest("--run-integration")
+    result.assert_outcomes(passed=1)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,25 +1,16 @@
 # -*- coding: utf-8 -*-
 
-from .common import (
-    sys,
-    os,
-    json,
-    re,
-    time,
-    api,
-    utils,
-    pytest,
-)
+from .common import api, json, os, pytest, re, sys, time, utils
 
-pytest.skip("Heavy integration tests skipped", allow_module_level=True)
+pytestmark = pytest.mark.integration
 
 __movie_video_meta = {
-    'year': '2016',
-    'title': 'Fantastic Beasts and Where to Find Them',
-    'imdb_id': 'tt3183660',
-    'filename': 'Fantastic.Beasts.and.Where.to.Find.Them.2016.1080p.BluRay.x264.DTS-JYK.mkv',
-    'filesize': '3592482379',
-    'filehash': '4985126cbf92fe60',
+    "year": "2016",
+    "title": "Fantastic Beasts and Where to Find Them",
+    "imdb_id": "tt3183660",
+    "filename": "Fantastic.Beasts.and.Where.to.Find.Them.2016.1080p.BluRay.x264.DTS-JYK.mkv",
+    "filesize": "3592482379",
+    "filehash": "4985126cbf92fe60",
 }
 
 __tvshow_video_meta = {
@@ -33,7 +24,7 @@ __tvshow_video_meta = {
     "filesize": "3280755286",
     "filehash": "ec26d882048dde98",
 }
-__tvshow_expected_year = '2016'
+__tvshow_expected_year = "2016"
 
 __tvshow_unicode_video_meta = {
     "year": "2019",
@@ -48,15 +39,15 @@ __tvshow_unicode_video_meta = {
 }
 
 __tvshow_with_show_imdb_id_video_meta = __tvshow_video_meta.copy()
-__tvshow_with_show_imdb_id_video_meta['imdb_id'] = 'tt0475784'
-__tvshow_with_show_imdb_id_expected_year = '2016'
+__tvshow_with_show_imdb_id_video_meta["imdb_id"] = "tt0475784"
+__tvshow_with_show_imdb_id_expected_year = "2016"
 
 __tvshow_with_show_imdb_id_missing_year_meta = __tvshow_video_meta.copy()
-__tvshow_with_show_imdb_id_missing_year_meta['imdb_id'] = 'tt0475784'
-__tvshow_with_show_imdb_id_missing_year_meta['year'] = ''
-__tvshow_with_show_imdb_id_missing_year_meta_expected_imdb_id = 'tt8358332'
-__tvshow_with_show_imdb_id_missing_year_meta_expected_year = '2016'
-__tvshow_with_show_imdb_id_missing_year_meta_expected_ep_year = '2020'
+__tvshow_with_show_imdb_id_missing_year_meta["imdb_id"] = "tt0475784"
+__tvshow_with_show_imdb_id_missing_year_meta["year"] = ""
+__tvshow_with_show_imdb_id_missing_year_meta_expected_imdb_id = "tt8358332"
+__tvshow_with_show_imdb_id_missing_year_meta_expected_year = "2016"
+__tvshow_with_show_imdb_id_missing_year_meta_expected_ep_year = "2020"
 
 __tvshow_alt_title_video_meta = {
     "year": "2016",
@@ -69,33 +60,42 @@ __tvshow_alt_title_video_meta = {
     "filesize": "808387637",
     "filehash": "b3b923134834beee",
 }
-__tvshow_alt_title_expected_year = '2016'
+__tvshow_alt_title_expected_year = "2016"
 
 __tvshow_with_show_imdb_id_alt_title_video_meta = __tvshow_alt_title_video_meta.copy()
-__tvshow_with_show_imdb_id_alt_title_video_meta['imdb_id'] = 'tt6150576'
-__tvshow_with_show_imdb_id_alt_title_expected_year = '2016'
+__tvshow_with_show_imdb_id_alt_title_video_meta["imdb_id"] = "tt6150576"
+__tvshow_with_show_imdb_id_alt_title_expected_year = "2016"
 
-os.environ.setdefault('A4KSUBTITLES_TESTRUN', 'true')
+os.environ.setdefault("A4KSUBTITLES_TESTRUN", "true")
+
 
 def __remove_meta_cache(a4ksubtitles_api):
     try:
         os.remove(a4ksubtitles_api.core.cache.__meta_cache_filepath)
-    except: pass
+    except:
+        pass
+
 
 def __remove_imdb_id_cache(a4ksubtitles_api):
     try:
         os.remove(a4ksubtitles_api.core.cache.__imdb_id_cache_filepath)
-    except: pass
+    except:
+        pass
+
 
 def __remove_tvshow_years_cache(a4ksubtitles_api):
     try:
         os.remove(a4ksubtitles_api.core.cache.__tvshow_years_cache_filepath)
-    except: pass
+    except:
+        pass
+
 
 def __remove_last_results(a4ksubtitles_api):
     try:
         os.remove(a4ksubtitles_api.core.cache.results_filepath)
-    except: pass
+    except:
+        pass
+
 
 def __remove_all_cache(a4ksubtitles_api):
     __remove_imdb_id_cache(a4ksubtitles_api)
@@ -103,202 +103,271 @@ def __remove_all_cache(a4ksubtitles_api):
     __remove_tvshow_years_cache(a4ksubtitles_api)
     __remove_last_results(a4ksubtitles_api)
 
-def __search(a4ksubtitles_api, settings={}, video_meta={}, languages='English'):
+
+def __search(a4ksubtitles_api, settings={}, video_meta={}, languages="English"):
     search = lambda: None
     search.params = {
-        'languages': languages,
-        'preferredlanguage': '',
+        "languages": languages,
+        "preferredlanguage": "",
     }
 
     search.settings = {
-        'general.timeout': '30',
-        'general.results_limit': '20',
-        'opensubtitles.enabled': 'false',
-        'opensubtitles.username': '',
-        'opensubtitles.password': '',
-        'bsplayer.enabled': 'false',
-        'podnadpisi.enabled': 'false',
-        'subdl.enabled': 'false',
-        'addic7ed.enabled': 'false',
-        'subsource.enabled': 'false',
+        "general.timeout": "30",
+        "general.results_limit": "20",
+        "opensubtitles.enabled": "false",
+        "opensubtitles.username": "",
+        "opensubtitles.password": "",
+        "bsplayer.enabled": "false",
+        "podnadpisi.enabled": "false",
+        "subdl.enabled": "false",
+        "addic7ed.enabled": "false",
+        "subsource.enabled": "false",
     }
     search.settings.update(settings)
 
     search.video_meta = {}
     search.video_meta.update(video_meta)
 
-    search.results = a4ksubtitles_api.search(search.params, search.settings, search.video_meta)
+    search.results = a4ksubtitles_api.search(
+        search.params, search.settings, search.video_meta
+    )
 
     return search
 
-def __search_movie(a4ksubtitles_api, settings={}, video_meta={}, languages='English'):
+
+def __search_movie(a4ksubtitles_api, settings={}, video_meta={}, languages="English"):
     movie_video_meta = __movie_video_meta.copy()
     movie_video_meta.update(video_meta)
     return __search(a4ksubtitles_api, settings, movie_video_meta, languages)
 
-def __search_tvshow(a4ksubtitles_api, settings={}, video_meta={}, languages='English'):
+
+def __search_tvshow(a4ksubtitles_api, settings={}, video_meta={}, languages="English"):
     tvshow_video_meta = __tvshow_video_meta.copy()
     tvshow_video_meta.update(video_meta)
     return __search(a4ksubtitles_api, settings, tvshow_video_meta, languages)
+
 
 def __search_tvshow_alt_title(a4ksubtitles_api, settings={}, video_meta={}):
     tvshow_video_meta = __tvshow_alt_title_video_meta.copy()
     tvshow_video_meta.update(video_meta)
     return __search(a4ksubtitles_api, settings, tvshow_video_meta)
 
+
 def __search_unicode_tvshow(a4ksubtitles_api, settings={}, video_meta={}):
     tvshow_video_meta = __tvshow_unicode_video_meta.copy()
     tvshow_video_meta.update(video_meta)
     return __search(a4ksubtitles_api, settings, tvshow_video_meta)
+
 
 def __search_tvshow_with_show_imdb_id(a4ksubtitles_api, settings={}, video_meta={}):
     tvshow_video_meta = __tvshow_with_show_imdb_id_video_meta.copy()
     tvshow_video_meta.update(video_meta)
     return __search(a4ksubtitles_api, settings, tvshow_video_meta)
 
-def __search_tvshow_with_show_imdb_id_alt_title(a4ksubtitles_api, settings={}, video_meta={}):
+
+def __search_tvshow_with_show_imdb_id_alt_title(
+    a4ksubtitles_api, settings={}, video_meta={}
+):
     tvshow_video_meta = __tvshow_with_show_imdb_id_alt_title_video_meta.copy()
     tvshow_video_meta.update(video_meta)
     return __search(a4ksubtitles_api, settings, tvshow_video_meta)
 
-def __search_tvshow_with_show_imdb_id_missing_year(a4ksubtitles_api, settings={}, video_meta={}):
+
+def __search_tvshow_with_show_imdb_id_missing_year(
+    a4ksubtitles_api, settings={}, video_meta={}
+):
     tvshow_video_meta = __tvshow_with_show_imdb_id_missing_year_meta.copy()
     tvshow_video_meta.update(video_meta)
     return __search(a4ksubtitles_api, settings, tvshow_video_meta)
 
+
 def test_search_missing_imdb_id():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
-    log_error_spy = utils.spy_fn(a4ksubtitles_api.core.logger, 'error')
+    log_error_spy = utils.spy_fn(a4ksubtitles_api.core.logger, "error")
 
     params = {
-        'languages': 'English',
-        'preferredlanguage': '',
+        "languages": "English",
+        "preferredlanguage": "",
     }
     a4ksubtitles_api.search(params, {}, {})
 
     log_error_spy.restore()
-    log_error_spy.called_with('missing imdb id!')
+    log_error_spy.called_with("missing imdb id!")
+
 
 def test_tvshow_year_scraping_with_episode_imdb_id():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
-    get_meta_spy = utils.spy_fn(a4ksubtitles_api.core.video, 'get_meta', return_result=False)
+    get_meta_spy = utils.spy_fn(
+        a4ksubtitles_api.core.video, "get_meta", return_result=False
+    )
 
-    try: __search_tvshow(a4ksubtitles_api, {'podnadpisi.enabled': 'true'})
-    except: pass
+    try:
+        __search_tvshow(a4ksubtitles_api, {"podnadpisi.enabled": "true"})
+    except:
+        pass
 
     get_meta_spy.restore()
     assert get_meta_spy.result[0].tvshow_year == __tvshow_expected_year
 
+
 def test_tvshow_year_scraping_with_episode_imdb_id_alt_title():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
-    get_meta_spy = utils.spy_fn(a4ksubtitles_api.core.video, 'get_meta', return_result=False)
+    get_meta_spy = utils.spy_fn(
+        a4ksubtitles_api.core.video, "get_meta", return_result=False
+    )
 
-    try: __search_tvshow_alt_title(a4ksubtitles_api, {'podnadpisi.enabled': 'true'})
-    except: pass
+    try:
+        __search_tvshow_alt_title(a4ksubtitles_api, {"podnadpisi.enabled": "true"})
+    except:
+        pass
 
     get_meta_spy.restore()
     assert get_meta_spy.result[0].tvshow_year == __tvshow_alt_title_expected_year
 
+
 def test_tvshow_year_scraping_with_show_imdb_id():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
-    get_meta_spy = utils.spy_fn(a4ksubtitles_api.core.video, 'get_meta', return_result=False)
+    get_meta_spy = utils.spy_fn(
+        a4ksubtitles_api.core.video, "get_meta", return_result=False
+    )
 
-    try: __search_tvshow_with_show_imdb_id(a4ksubtitles_api, {'podnadpisi.enabled': 'true'})
-    except: pass
+    try:
+        __search_tvshow_with_show_imdb_id(
+            a4ksubtitles_api, {"podnadpisi.enabled": "true"}
+        )
+    except:
+        pass
 
     get_meta_spy.restore()
-    assert get_meta_spy.result[0].tvshow_year == __tvshow_with_show_imdb_id_expected_year
+    assert (
+        get_meta_spy.result[0].tvshow_year == __tvshow_with_show_imdb_id_expected_year
+    )
+
 
 def test_tvshow_year_scraping_with_show_imdb_id_alt_title():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
-    get_meta_spy = utils.spy_fn(a4ksubtitles_api.core.video, 'get_meta', return_result=False)
+    get_meta_spy = utils.spy_fn(
+        a4ksubtitles_api.core.video, "get_meta", return_result=False
+    )
 
-    try: __search_tvshow_with_show_imdb_id_alt_title(a4ksubtitles_api, {'podnadpisi.enabled': 'true'})
-    except: pass
+    try:
+        __search_tvshow_with_show_imdb_id_alt_title(
+            a4ksubtitles_api, {"podnadpisi.enabled": "true"}
+        )
+    except:
+        pass
 
     get_meta_spy.restore()
-    assert get_meta_spy.result[0].tvshow_year == __tvshow_with_show_imdb_id_alt_title_expected_year
+    assert (
+        get_meta_spy.result[0].tvshow_year
+        == __tvshow_with_show_imdb_id_alt_title_expected_year
+    )
+
 
 def test_tvshow_year_scraping_with_show_imdb_id_missing_year():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
-    get_meta_spy = utils.spy_fn(a4ksubtitles_api.core.video, 'get_meta', return_result=False)
+    get_meta_spy = utils.spy_fn(
+        a4ksubtitles_api.core.video, "get_meta", return_result=False
+    )
 
-    try: __search_tvshow_with_show_imdb_id_missing_year(a4ksubtitles_api, {'podnadpisi.enabled': 'true'})
-    except: pass
+    try:
+        __search_tvshow_with_show_imdb_id_missing_year(
+            a4ksubtitles_api, {"podnadpisi.enabled": "true"}
+        )
+    except:
+        pass
 
     get_meta_spy.restore()
-    assert get_meta_spy.result[0].tvshow_year == __tvshow_with_show_imdb_id_missing_year_meta_expected_year
-    assert get_meta_spy.result[0].year == __tvshow_with_show_imdb_id_missing_year_meta_expected_ep_year
-    assert get_meta_spy.result[0].imdb_id == __tvshow_with_show_imdb_id_missing_year_meta_expected_imdb_id
+    assert (
+        get_meta_spy.result[0].tvshow_year
+        == __tvshow_with_show_imdb_id_missing_year_meta_expected_year
+    )
+    assert (
+        get_meta_spy.result[0].year
+        == __tvshow_with_show_imdb_id_missing_year_meta_expected_ep_year
+    )
+    assert (
+        get_meta_spy.result[0].imdb_id
+        == __tvshow_with_show_imdb_id_missing_year_meta_expected_imdb_id
+    )
+
 
 def test_opensubtitles():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     search = __search_movie(a4ksubtitles_api, settings)
 
     assert len(search.results) == 20
 
-    expected_result_name = 'Fantastic.Beasts.and.Where.to.Find.Them.2016.1080p.BluRay.x264.DTS-JYK'
-    expected_result_name2 = 'Fantastic.Beasts.and.Where.to.Find.Them.2016.1080p.BluRay.x264.DTS-FGT'
-    assert search.results[0]['name'] == expected_result_name or search.results[0]['name'] == expected_result_name2
+    expected_result_name = (
+        "Fantastic.Beasts.and.Where.to.Find.Them.2016.1080p.BluRay.x264.DTS-JYK"
+    )
+    expected_result_name2 = (
+        "Fantastic.Beasts.and.Where.to.Find.Them.2016.1080p.BluRay.x264.DTS-FGT"
+    )
+    assert (
+        search.results[0]["name"] == expected_result_name
+        or search.results[0]["name"] == expected_result_name2
+    )
 
     __remove_all_cache(a4ksubtitles_api)
 
     # search (imdb only)
     video_meta = {
-        'filesize': '',
-        'filehash': '',
+        "filesize": "",
+        "filehash": "",
     }
     search = __search_movie(a4ksubtitles_api, settings, video_meta)
 
     assert len(search.results) == 20
 
-    if a4ksubtitles_api.core.os.getenv('A4KSUBTITLES_TESTRUN') == 'true':
+    if a4ksubtitles_api.core.os.getenv("A4KSUBTITLES_TESTRUN") == "true":
         return
 
     # download
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'opensubtitles',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "opensubtitles",
+        "action_args": item["action_args"],
     }
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
 
     # remove_ads
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         sub_contents = f.read()
 
-    assert re.match(r'.*OpenSubtitles.*', sub_contents, re.DOTALL) is None
+    assert re.match(r".*OpenSubtitles.*", sub_contents, re.DOTALL) is None
+
 
 def test_opensubtitles_tvshow():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     search = __search_tvshow(a4ksubtitles_api, settings)
 
@@ -306,25 +375,26 @@ def test_opensubtitles_tvshow():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'opensubtitles',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "opensubtitles",
+        "action_args": item["action_args"],
     }
 
-    if a4ksubtitles_api.core.os.getenv('A4KSUBTITLES_TESTRUN') == 'true':
+    if a4ksubtitles_api.core.os.getenv("A4KSUBTITLES_TESTRUN") == "true":
         return
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_opensubtitles_unicode_tvshow():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     search = __search_unicode_tvshow(a4ksubtitles_api, settings)
 
@@ -332,108 +402,114 @@ def test_opensubtitles_unicode_tvshow():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'opensubtitles',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "opensubtitles",
+        "action_args": item["action_args"],
     }
 
-    if a4ksubtitles_api.core.os.getenv('A4KSUBTITLES_TESTRUN') == 'true':
+    if a4ksubtitles_api.core.os.getenv("A4KSUBTITLES_TESTRUN") == "true":
         return
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_opensubtitles_missing_imdb_id():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     video_meta = {
-        'imdb_id': '',
+        "imdb_id": "",
     }
     search = __search_movie(a4ksubtitles_api, settings, video_meta)
 
     assert len(search.results) > 0
+
 
 def test_opensubtitles_missing_imdb_id_but_in_url():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     video_meta = {
-        'imdb_id': '',
-        'url': 'https://example.com/example.mkv?imdb_id=tt3183660'
+        "imdb_id": "",
+        "url": "https://example.com/example.mkv?imdb_id=tt3183660",
     }
     search = __search_movie(a4ksubtitles_api, settings, video_meta)
 
     assert len(search.results) > 0
 
+
 def test_opensubtitles_tvshow_missing_imdb_id():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     video_meta = {
-        'imdb_id': '',
+        "imdb_id": "",
     }
     search = __search_tvshow(a4ksubtitles_api, settings, video_meta)
 
     assert len(search.results) > 0
+
 
 def test_opensubtitles_tvshow_missing_imdb_id_but_in_url():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     video_meta = {
-        'imdb_id': '',
-        'season': '',
-        'episode': '',
-        'url': 'https://example.com/example.mkv?imdb_id=tt11610548'
+        "imdb_id": "",
+        "season": "",
+        "episode": "",
+        "url": "https://example.com/example.mkv?imdb_id=tt11610548",
     }
     search = __search_tvshow(a4ksubtitles_api, settings, video_meta)
 
     assert len(search.results) > 0
+
 
 def test_opensubtitles_tvshow_missing_imdb_id_but_in_url_with_show_id_and_meta_for_ep_and_season():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'opensubtitles.enabled': 'true',
+        "opensubtitles.enabled": "true",
     }
     video_meta = {
-        'imdb_id': '',
-        'season': '',
-        'episode': '',
-        'url': 'https://example.com/example.mkv?imdb_id=tt10155688&season=1&episode=2'
+        "imdb_id": "",
+        "season": "",
+        "episode": "",
+        "url": "https://example.com/example.mkv?imdb_id=tt10155688&season=1&episode=2",
     }
     search = __search_tvshow(a4ksubtitles_api, settings, video_meta)
 
     assert len(search.results) > 0
 
+
 def test_bsplayer():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
-    request_execute_spy = utils.spy_fn(a4ksubtitles_api.core.request, 'execute')
+    request_execute_spy = utils.spy_fn(a4ksubtitles_api.core.request, "execute")
 
     # search
     settings = {
-        'bsplayer.enabled': 'true',
+        "bsplayer.enabled": "true",
     }
     search = __search_movie(a4ksubtitles_api, settings)
 
@@ -442,12 +518,12 @@ def test_bsplayer():
 
     assert len(search.results) == 16
 
-    expected_result_name = os.path.splitext(search.video_meta['filename'])[0]
-    result_name = os.path.splitext(search.results[0]['name'])[0]
+    expected_result_name = os.path.splitext(search.video_meta["filename"])[0]
+    result_name = os.path.splitext(search.results[0]["name"])[0]
     assert expected_result_name == result_name
 
     # cache
-    request_execute_spy = utils.spy_fn(a4ksubtitles_api.core.request, 'execute')
+    request_execute_spy = utils.spy_fn(a4ksubtitles_api.core.request, "execute")
     __search_movie(a4ksubtitles_api, settings)
 
     assert request_execute_spy.call_count == 1
@@ -458,22 +534,23 @@ def test_bsplayer():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'bsplayer',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "bsplayer",
+        "action_args": item["action_args"],
     }
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_bsplayer_tvshow():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'bsplayer.enabled': 'true',
+        "bsplayer.enabled": "true",
     }
     search = __search_tvshow(a4ksubtitles_api, settings)
 
@@ -481,22 +558,23 @@ def test_bsplayer_tvshow():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'bsplayer',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "bsplayer",
+        "action_args": item["action_args"],
     }
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_podnadpisi():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'podnadpisi.enabled': 'true',
+        "podnadpisi.enabled": "true",
     }
     search = __search_movie(a4ksubtitles_api, settings)
 
@@ -504,22 +582,23 @@ def test_podnadpisi():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'podnadpisi',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "podnadpisi",
+        "action_args": item["action_args"],
     }
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_podnadpisi_tvshow():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'podnadpisi.enabled': 'true',
+        "podnadpisi.enabled": "true",
     }
     search = __search_tvshow(a4ksubtitles_api, settings)
 
@@ -527,32 +606,34 @@ def test_podnadpisi_tvshow():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'podnadpisi',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "podnadpisi",
+        "action_args": item["action_args"],
     }
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_podnadpisi_tvshow_missing_imdb_id_but_in_url_with_show_id_and_meta_for_ep_and_season_with_paging():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'podnadpisi.enabled': 'true',
+        "podnadpisi.enabled": "true",
     }
     video_meta = {
-        'imdb_id': '',
-        'season': '',
-        'episode': '',
-        'url': 'https://example.com/example.mkv?imdb_id=tt0239195&season=20&episode=2'
+        "imdb_id": "",
+        "season": "",
+        "episode": "",
+        "url": "https://example.com/example.mkv?imdb_id=tt0239195&season=20&episode=2",
     }
     search = __search_tvshow(a4ksubtitles_api, settings, video_meta)
 
     assert len(search.results) > 0
+
 
 # def test_subdl():
 #     a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
@@ -674,13 +755,14 @@ def test_podnadpisi_tvshow_missing_imdb_id_but_in_url_with_show_id_and_meta_for_
 
 #     assert filepath != ''
 
+
 def test_addic7ed_tvshow():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'addic7ed.enabled': 'true',
+        "addic7ed.enabled": "true",
     }
     search = __search_tvshow(a4ksubtitles_api, settings)
 
@@ -688,27 +770,28 @@ def test_addic7ed_tvshow():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'addic7ed',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "addic7ed",
+        "action_args": item["action_args"],
     }
 
     try:
         filepath = a4ksubtitles_api.download(params, search.settings)
     except Exception as e:
-        if 'object does not support the context manager protocol' in str(e):
-            print('Skipping test_addic7ed_tvshow')
+        if "object does not support the context manager protocol" in str(e):
+            print("Skipping test_addic7ed_tvshow")
             return
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_subsource():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'subsource.enabled': 'true',
+        "subsource.enabled": "true",
     }
     search = __search_movie(a4ksubtitles_api, settings)
 
@@ -716,28 +799,29 @@ def test_subsource():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'subsource',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "subsource",
+        "action_args": item["action_args"],
     }
 
-    if os.getenv('CI', None) is not None:
+    if os.getenv("CI", None) is not None:
         time.sleep(4)
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_subsource_tvshow():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'subsource.enabled': 'true',
+        "subsource.enabled": "true",
     }
 
-    if os.getenv('CI', None) is not None:
+    if os.getenv("CI", None) is not None:
         time.sleep(4)
 
     search = __search_tvshow(a4ksubtitles_api, settings)
@@ -746,44 +830,45 @@ def test_subsource_tvshow():
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'subsource',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "subsource",
+        "action_args": item["action_args"],
     }
 
-    if os.getenv('CI', None) is not None:
+    if os.getenv("CI", None) is not None:
         time.sleep(4)
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""
+
 
 def test_subsource_arabic():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
     __remove_all_cache(a4ksubtitles_api)
 
     # search
     settings = {
-        'subsource.enabled': 'true',
+        "subsource.enabled": "true",
     }
 
-    if os.getenv('CI', None) is not None:
+    if os.getenv("CI", None) is not None:
         time.sleep(4)
 
-    search = __search_movie(a4ksubtitles_api, settings, {}, 'Arabic')
+    search = __search_movie(a4ksubtitles_api, settings, {}, "Arabic")
 
     # download
     item = search.results[0]
 
     params = {
-        'action': 'download',
-        'service_name': 'subsource',
-        'action_args': item['action_args']
+        "action": "download",
+        "service_name": "subsource",
+        "action_args": item["action_args"],
     }
 
-    if os.getenv('CI', None) is not None:
+    if os.getenv("CI", None) is not None:
         time.sleep(4)
 
     filepath = a4ksubtitles_api.download(params, search.settings)
 
-    assert filepath != ''
+    assert filepath != ""


### PR DESCRIPTION
## Summary
- replace unconditional skip in `tests/test_suite.py` with an `integration` marker
- add `--run-integration` CLI flag to enable integration tests
- document running integration tests in README and CONTRIBUTING
- add regression test ensuring integration tests are skipped by default and only run when `--run-integration` is passed

## Testing
- `pre-commit run --files tests/test_opt_integration_marker.py`
- `pytest`
- `pytest tests/test_suite.py::test_search_missing_imdb_id --run-integration`


------
https://chatgpt.com/codex/tasks/task_e_6894abe17ad8832fb45da012aa09dab1