### PR TITLE
chore: add preflight script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,14 @@ We welcome pull requests for bug fixes and improvements.
 
 #### Running Linters and Tests
 
+To run all linters and the test suite in one step before committing or pushing, use the preflight script:
+
+```bash
+scripts/preflight.sh
+```
+
+It executes `pre-commit run --all-files` and `pytest` to catch formatting issues and failing tests early.
+
 *   **Install pre-commit hooks:**
 
 *   **Pre-commit:** Run the pre-commit hooks to format and lint code:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ pytest --run-integration
 
 We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to report issues, suggest features, and submit pull requests. Note that our pre-commit configuration excludes bundled third-party modules under `a4kSubtitles/lib/third_party/`, so those files are intentionally not edited or linted.
 
+Before committing or pushing changes, run the preflight script to execute the linters and tests:
+
+```bash
+scripts/preflight.sh
+```
+
+This script runs `pre-commit run --all-files` and `pytest` to catch formatting problems and failing tests early.
+
 ## Icon
 
 Original logo `quill` by Ramy Wafaa ([RoundIcons](https://roundicons.com)).

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+pre-commit run --all-files
+pytest


### PR DESCRIPTION
## Summary
- add preflight script to run linters and tests
- document running `scripts/preflight.sh` before commits or pushes

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68974ef554e8832f910305562be1fd74