### PR TITLE
chore: add editorconfig and git attributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps maintain consistent coding styles
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,20 @@
+# Auto-detect text files and perform LF normalization
+* text=auto eol=lf
+
+# Common binary file types
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.zip binary
+
+# Linguist hints
+packages/* linguist-generated
+
+# Release packaging
 .*                  export-ignore
 packages            export-ignore
 scripts             export-ignore
 tests               export-ignore
 requirements.txt    export-ignore
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Unreleased:
+  * Normalize line endings and add linguist hints in `.gitattributes`.
+  * Introduce `.editorconfig` for consistent formatting across editors.
+
 * PolyglotSubs-Kodi:
   * Forked from [a4kSubtitles](https://github.com/a4k-openproject/a4kSubtitles) and maintained separately.
   * Adds Subtitlecat.com provider with on-demand subtitle translation and optional sharing of translated subtitles.


### PR DESCRIPTION
## Summary
- normalize line endings and add linguist hints in `.gitattributes`
- add `.editorconfig` for consistent formatting
- document configuration changes in changelog

## Testing
- `pre-commit run --files .gitattributes .editorconfig CHANGELOG.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4612b728832fa577dffcbb90e65f