### PR TITLE
Sync pyproject dependencies with requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ authors = [{name="Sebastian Vannistel"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "requests",
-    "beautifulsoup4",
+    "requests>=2.32,<3",
+    "urllib3>=1.26,<3",
+    "charset-normalizer>=3,<4",
+    "chardet>=5,<6",
+    "beautifulsoup4>=4.12,<5",
 ]

--- a/tests/test_dependencies_sync.py
+++ b/tests/test_dependencies_sync.py
@@ -1,0 +1,16 @@
+import tomllib
+from pathlib import Path
+
+
+def test_project_dependencies_match_requirements():
+    root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text("utf-8"))
+    pyproject_deps = set(pyproject["project"]["dependencies"])
+
+    with (root / "requirements.txt").open() as req_file:
+        requirements = {
+            line.strip() for line in req_file
+            if line.strip() and not line.startswith("#")
+        }
+
+    assert pyproject_deps == requirements


### PR DESCRIPTION
## Summary
- mirror pinned versions from requirements.txt in pyproject.toml
- add test ensuring pyproject dependencies stay in sync with requirements.txt

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4cec6374832fbd70561e811400c2