### PR TITLE
Drop chardet dependency in favor of charset-normalizer

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 requests>=2.32,<3
 urllib3>=1.26,<3
 charset-normalizer>=3,<4
-chardet>=5,<6
 beautifulsoup4>=4.12,<5
 pytest>=7,<9
 flake8>=6,<7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.32,<3
 urllib3>=1.26,<3
 charset-normalizer>=3,<4
-chardet>=5,<6
 beautifulsoup4>=4.12,<5


### PR DESCRIPTION
## Summary
- remove `chardet` from runtime and dev requirements to rely on `charset-normalizer`
- verify that `requests` depends on `charset-normalizer`

## Testing
- `pre-commit run --files requirements.txt requirements-dev.txt`
- `pytest -q`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_689c4ceb3660832fa0ac33eb6bf9b7cd