### PR TITLE
refactor: narrow exception handling and improve logging

### DIFF
--- a/a4kSubtitles/lib/kodi.py
+++ b/a4kSubtitles/lib/kodi.py
@@ -1,26 +1,30 @@
 # -*- coding: utf-8 -*-
 
-import os
-import sys
-import json
-import re
 import importlib
+import json
+import logging
+import os
+import re
+import sys
 
 kodi = sys.modules[__name__]
-api_mode = os.getenv('A4KSUBTITLES_API_MODE')
+api_mode = os.getenv("A4KSUBTITLES_API_MODE")
 
 if api_mode:
-    try: api_mode = json.loads(api_mode)
-    except: api_mode = None
+    try:
+        api_mode = json.loads(api_mode)
+    except ValueError as e:
+        logging.getLogger(__name__).error("Invalid A4KSUBTITLES_API_MODE: %s", e)
+        api_mode = None
 
 if api_mode:
-    if api_mode.get('kodi', False):
-        from .kodi_mock import xbmc, xbmcaddon, xbmcplugin, xbmcgui, xbmcvfs
+    if api_mode.get("kodi", False):
+        from .kodi_mock import xbmc, xbmcaddon, xbmcgui, xbmcplugin, xbmcvfs
     else:
         from . import kodi_mock
 
-        for target in ['xbmc', 'xbmcaddon', 'xbmcplugin', 'xbmcgui', 'xbmcvfs']:
-            if target == 'kodi':
+        for target in ["xbmc", "xbmcaddon", "xbmcplugin", "xbmcgui", "xbmcvfs"]:
+            if target == "kodi":
                 continue
             elif api_mode.get(target, False):
                 mod = getattr(kodi_mock, target)
@@ -31,149 +35,182 @@ if api_mode:
 else:  # pragma: no cover
     import xbmc
     import xbmcaddon
-    import xbmcplugin
     import xbmcgui
+    import xbmcplugin
     import xbmcvfs
 
 addon = xbmcaddon.Addon()
-addon_id = addon.getAddonInfo('id')
-addon_name = addon.getAddonInfo('name')
-addon_version = addon.getAddonInfo('version')
-addon_icon = addon.getAddonInfo('icon')
+addon_id = addon.getAddonInfo("id")
+addon_name = addon.getAddonInfo("name")
+addon_version = addon.getAddonInfo("version")
+addon_icon = addon.getAddonInfo("icon")
 try:
-    addon_profile = xbmcvfs.translatePath(addon.getAddonInfo('profile'))
-except:
-    addon_profile = xbmc.translatePath(addon.getAddonInfo('profile'))
+    addon_profile = xbmcvfs.translatePath(addon.getAddonInfo("profile"))
+except AttributeError as e:
+    logging.getLogger(__name__).debug("xbmcvfs.translatePath not available: %s", e)
+    addon_profile = xbmc.translatePath(addon.getAddonInfo("profile"))
+
 
 def json_rpc(method, params, log_error=True):  # pragma: no cover
     try:
         result = xbmc.executeJSONRPC(
-            json.dumps({
-                'jsonrpc': '2.0',
-                'method': method,
-                'id': 1,
-                'params': params or {}
-            })
+            json.dumps(
+                {"jsonrpc": "2.0", "method": method, "id": 1, "params": params or {}}
+            )
         )
-        if 'error' in result and log_error:
+        if "error" in result and log_error:
             from . import logger
+
             logger.error(result)
-        result = json.loads(result)['result']
+        result = json.loads(result)["result"]
         try:
-            return result['value']
-        except:
+            return result["value"]
+        except (KeyError, TypeError) as e:
+            if log_error:
+                from . import logger
+
+                logger.error("Invalid JSON-RPC result structure: %s" % e)
             return result
     except KeyError:
         return None
 
+
 def get_kodi_setting(setting, log_error=True):  # pragma: no cover
-    return json_rpc('Settings.GetSettingValue', {"setting": setting}, log_error)
+    return json_rpc("Settings.GetSettingValue", {"setting": setting}, log_error)
+
 
 def get_kodi_player_subtitles(log_error=True):  # pragma: no cover
-    return json_rpc('Player.GetProperties', {"playerid": 1, "properties": ["subtitleenabled", "currentsubtitle", "subtitles"]}, log_error)
+    return json_rpc(
+        "Player.GetProperties",
+        {
+            "playerid": 1,
+            "properties": ["subtitleenabled", "currentsubtitle", "subtitles"],
+        },
+        log_error,
+    )
+
 
 def notification(text, time=3000):  # pragma: no cover
-    xbmc.executebuiltin('Notification(%s, %s, %d, %s)' % (addon_name, text, time, addon_icon))
+    xbmc.executebuiltin(
+        "Notification(%s, %s, %d, %s)" % (addon_name, text, time, addon_icon)
+    )
+
 
 def get_progress_dialog():  # pragma: no cover
     wrapper = lambda: None
     wrapper.dialog = None
     wrapper.latest_update = None
+
     def open():
         wrapper.dialog = xbmcgui.DialogProgress()
-        wrapper.dialog.create(addon_name, 'Searching...')
+        wrapper.dialog.create(addon_name, "Searching...")
         if wrapper.latest_update:
             (progress, text) = wrapper.latest_update
             wrapper.dialog.update(progress, text)
+
     def close():
         if wrapper.dialog:
             wrapper.dialog.close()
             wrapper.dialog = None
+
     def iscanceled():
         return wrapper.dialog.iscanceled() if wrapper.dialog else False
+
     def update(progress, text):
         if wrapper.dialog:
             wrapper.dialog.update(progress, text)
         else:
             wrapper.latest_update = (progress, text)
+
     wrapper.open = open
     wrapper.close = close
     wrapper.iscanceled = iscanceled
     wrapper.update = update
     return wrapper
 
+
 def update_progress(core):  # pragma: no cover
     if core.progress_dialog is None or core.progress_dialog.iscanceled():
         return
 
-    text = re.sub(r'\|+', '|', core.progress_text).strip('|')
-    total = core.progress_text.count('|') + 1
-    count = text.count('|') + 1 if text != '' else 0
+    text = re.sub(r"\|+", "|", core.progress_text).strip("|")
+    total = core.progress_text.count("|") + 1
+    count = text.count("|") + 1 if text != "" else 0
     progress = int(float(total - count) / total * 100)
-    core.progress_dialog.update(progress, text.replace('|', ' | '))
+    core.progress_dialog.update(progress, text.replace("|", " | "))
+
 
 def parse_language(language):  # pragma: no cover
-    if language == 'original':
+    if language == "original":
         audio_streams = xbmc.Player().getAvailableAudioStreams()
         if len(audio_streams) == 0:
             return None
-        return xbmc.convertLanguage(
-            audio_streams[0],
-            xbmc.ENGLISH_NAME
-        )
-    elif language == 'default':
+        return xbmc.convertLanguage(audio_streams[0], xbmc.ENGLISH_NAME)
+    elif language == "default":
         return xbmc.getLanguage()
-    elif language == 'none':
+    elif language == "none":
         return None
-    elif language == 'forced_only':
+    elif language == "forced_only":
         return parse_language(get_kodi_setting("locale.audiolanguage"))
     else:
         return language
 
+
 def create_listitem(item):  # pragma: no cover
-    (item_name, item_ext) = os.path.splitext(item['name'])
-    item_name = item_name.replace('.', ' ')
+    (item_name, item_ext) = os.path.splitext(item["name"])
+    item_name = item_name.replace(".", " ")
     item_ext = item_ext.upper()[1:]
-    item_service = item['service']
-    item_color = item.get('color', 'white')
+    item_service = item["service"]
+    item_color = item.get("color", "white")
 
     args = {
-        'label': item['lang'],
-        'label2': '%s ([B]%s[/B]) ([B][COLOR %s]%s[/COLOR][/B])' % (item_name, item_ext, item_color, item_service),
-        'offscreen': True,
+        "label": item["lang"],
+        "label2": "%s ([B]%s[/B]) ([B][COLOR %s]%s[/COLOR][/B])"
+        % (item_name, item_ext, item_color, item_service),
+        "offscreen": True,
     }
 
     listitem = xbmcgui.ListItem(**args)
-    listitem.setArt({
-        'icon': str(item['rating']),
-        'thumb': item['lang_code'],
-    })
-    listitem.setProperty('sync', item['sync'])
-    listitem.setProperty('hearing_imp', item['impaired'])
+    listitem.setArt(
+        {
+            "icon": str(item["rating"]),
+            "thumb": item["lang_code"],
+        }
+    )
+    listitem.setProperty("sync", item["sync"])
+    listitem.setProperty("hearing_imp", item["impaired"])
 
     return listitem
 
+
 def get_setting(group, id=None):
-    key = '%s.%s' % (group, id) if id else group
+    key = "%s.%s" % (group, id) if id else group
     return addon.getSetting(key).strip()
+
 
 def get_int_setting(group, id=None):
     return int(get_setting(group, id))
 
+
 def get_bool_setting(group, id=None):
-    return get_setting(group, id).lower() == 'true'
+    return get_setting(group, id).lower() == "true"
+
 
 def get_versionstring():
-    return xbmc.getInfoLabel('System.BuildVersionCode')
+    return xbmc.getInfoLabel("System.BuildVersionCode")
+
 
 def get_version():
-    return list(map(int, get_versionstring().split('.')))
+    return list(map(int, get_versionstring().split(".")))
+
 
 def get_version_major():
     return get_version()[0]
 
+
 def get_version_minor():
     return get_version()[1]
+
 
 def get_version_patch():
     return get_version()[2]

--- a/a4kSubtitles/lib/utils.py
+++ b/a4kSubtitles/lib/utils.py
@@ -1,47 +1,72 @@
 # -*- coding: utf-8 -*-
 
-import os
-import sys
-import re
 import json
-import string
+import os
+import re
 import shutil
-from . import kodi
-from . import logger
+import string
+import sys
+
+try:
+    JSONDecodeError = json.JSONDecodeError
+except AttributeError:  # pragma: no cover
+    JSONDecodeError = ValueError
+
+from . import kodi, logger
 
 try:
     from .third_party import chardet, iso639
-except: pass
+    from .third_party.iso639.exceptions import (
+        DeprecatedLanguageValue,
+        InvalidLanguageValue,
+    )
+except ImportError as e:
+    logger.error("Failed to import third-party libraries: %s" % e)
 
 try:  # pragma: no cover
-    from urlparse import unquote, parse_qsl
     from urllib import quote_plus
-    from StringIO import StringIO
+
     import Queue as queue
+    from StringIO import StringIO
+    from urlparse import parse_qsl, unquote
 except ImportError:
-    from urllib.parse import quote_plus, unquote, parse_qsl
-    from io import StringIO
     import queue
+    from io import StringIO
+    from urllib.parse import parse_qsl, quote_plus, unquote
+
     unicode = lambda v: v
 
-__url_regex = r'[a-z0-9][a-z0-9-]{0,5}[a-z0-9]\.[a-z0-9]{2,20}\.[a-z]{2,5}'
-__credit_part_regex = r'(sync|synced|fix|fixed|corrected|corrections)'
-__credit_regex = __credit_part_regex + r' ?&? ?' + __credit_part_regex + r'? by'
+__url_regex = r"[a-z0-9][a-z0-9-]{0,5}[a-z0-9]\.[a-z0-9]{2,20}\.[a-z]{2,5}"
+__credit_part_regex = r"(sync|synced|fix|fixed|corrected|corrections)"
+__credit_regex = __credit_part_regex + r" ?&? ?" + __credit_part_regex + r"? by"
 
-default_encoding = 'utf-8'
-base_encoding = 'raw_unicode_escape'
-cp1251_garbled = u'аеио'.encode('cp1251').decode('raw_unicode_escape')
-koi8r_garbled = u'аеио'.encode('koi8-r').decode('raw_unicode_escape')
-code_pages = {'ara': 'cp1256', 'ar': 'cp1256', 'ell': 'cp1253', 'el': 'cp1253', 'heb': 'cp1255', 'he': 'cp1255', 'tur': 'cp1254', 'tr': 'cp1254', 'rus': 'cp1251', 'ru': 'cp1251', 'bg': 'cp1251'}
+default_encoding = "utf-8"
+base_encoding = "raw_unicode_escape"
+cp1251_garbled = "аеио".encode("cp1251").decode("raw_unicode_escape")
+koi8r_garbled = "аеио".encode("koi8-r").decode("raw_unicode_escape")
+code_pages = {
+    "ara": "cp1256",
+    "ar": "cp1256",
+    "ell": "cp1253",
+    "el": "cp1253",
+    "heb": "cp1255",
+    "he": "cp1255",
+    "tur": "cp1254",
+    "tr": "cp1254",
+    "rus": "cp1251",
+    "ru": "cp1251",
+    "bg": "cp1251",
+}
 
 zip_utf8_flag = 0x800
-py3_zip_missing_utf8_flag_fallback_encoding = 'cp437'
+py3_zip_missing_utf8_flag_fallback_encoding = "cp437"
 
 py2 = sys.version_info[0] == 2
 py3 = not py2
 
-temp_dir = os.path.join(kodi.addon_profile, 'temp')
-data_dir = os.path.join(kodi.addon_profile, 'data')
+temp_dir = os.path.join(kodi.addon_profile, "temp")
+data_dir = os.path.join(kodi.addon_profile, "data")
+
 
 class DictAsObject(dict):
     def __getattr__(self, name):
@@ -50,38 +75,48 @@ class DictAsObject(dict):
     def __setattr__(self, name, value):
         self[name] = value
 
-def get_all_relative_entries(relative_file, ext='.py', ignore_private=True):
+
+def get_all_relative_entries(relative_file, ext=".py", ignore_private=True):
     entries = os.listdir(os.path.dirname(relative_file))
-    return [os.path.splitext(name)[0] for name in entries if not ignore_private or not name.startswith('__') and name.endswith(ext)]
+    return [
+        os.path.splitext(name)[0]
+        for name in entries
+        if not ignore_private or not name.startswith("__") and name.endswith(ext)
+    ]
+
 
 def strip_non_ascii_and_unprintable(text):
     if not isinstance(text, str) and (not py2 or not isinstance(text, unicode)):
         return str(text)
 
-    result = ''.join(char for char in text if char in string.printable)
-    return result.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+    result = "".join(char for char in text if char in string.printable)
+    return result.encode("ascii", errors="ignore").decode("ascii", errors="ignore")
+
 
 def slugify_filename(text):
-    return re.sub(r'[\\/*?:"<>|]', '_', text)
+    return re.sub(r'[\\/*?:"<>|]', "_", text)
+
 
 def get_lang_id(language, lang_format):
     try:
         return get_lang_ids([language], lang_format)[0]
-    except:
-        return ''
+    except IndexError as e:
+        logger.error("Language id not found: %s" % e)
+        return ""
+
 
 def get_lang_ids(languages, lang_format=kodi.xbmc.ISO_639_2):
     try:
         lang_ids = []
         for language in languages:
             lang = language.lower()
-            if lang in ['pb', 'pob', 'pt-br'] or 'brazil' in lang:
+            if lang in ["pb", "pob", "pt-br"] or "brazil" in lang:
                 if lang_format == kodi.xbmc.ISO_639_1:
-                    lang_ids.append('pt-br')
+                    lang_ids.append("pt-br")
                 elif lang_format == kodi.xbmc.ISO_639_2:
-                    lang_ids.append('pob')
+                    lang_ids.append("pob")
                 elif lang_format == kodi.xbmc.ENGLISH_NAME:
-                    lang_ids.append('Portuguese (Brazil)')
+                    lang_ids.append("Portuguese (Brazil)")
                 continue
 
             lang = iso639.Lang(language)
@@ -98,8 +133,10 @@ def get_lang_ids(languages, lang_format=kodi.xbmc.ISO_639_2):
                 lang_ids.append(lang_id)
 
         return lang_ids
-    except:
+    except (InvalidLanguageValue, DeprecatedLanguageValue) as e:
+        logger.error("Invalid language value: %s" % e)
         return []
+
 
 def wait_threads(threads):
     for thread in threads:
@@ -107,75 +144,84 @@ def wait_threads(threads):
     for thread in threads:
         thread.join()
 
+
 def get_any_of_regex(array):
-    regex = r'('
+    regex = r"("
     for target in array:
-        regex += re.escape(target) + r'|'
-    return regex[:-1] + r')'
+        regex += re.escape(target) + r"|"
+    return regex[:-1] + r")"
+
 
 def cleanup_subtitles(core, sub_contents):
     service_names_regex = get_any_of_regex(core.services.keys())
-    all_lines = sub_contents.split('\n')
+    all_lines = sub_contents.split("\n")
     cleaned_lines = []
     buffer = []
     garbage = False
 
-    if all_lines[0].strip() != '':
-        all_lines.insert(0, '')
+    if all_lines[0].strip() != "":
+        all_lines.insert(0, "")
 
-    if all_lines[-1].strip() != '':
-        all_lines.append('')
+    if all_lines[-1].strip() != "":
+        all_lines.append("")
 
     for line in all_lines:
         line = line.strip()
 
-        if garbage and line != '':
+        if garbage and line != "":
             continue
 
         garbage = False
 
-        if line == '':
+        if line == "":
             if len(buffer) > 0:
-                buffer.insert(0, '')
+                buffer.insert(0, "")
                 cleaned_lines.extend(buffer)
                 buffer = []
             continue
 
         line_contains_ad = (
-            re.search(service_names_regex, line, re.IGNORECASE) or
-            re.search(__url_regex, line, re.IGNORECASE) or
-            re.search(__credit_regex, line, re.IGNORECASE)
+            re.search(service_names_regex, line, re.IGNORECASE)
+            or re.search(__url_regex, line, re.IGNORECASE)
+            or re.search(__credit_regex, line, re.IGNORECASE)
         )
 
         if line_contains_ad:
-            logger.debug('(detected ad) %s' % line.encode('ascii', errors='ignore'))
-            if not re.match(r'^\{\d+\}\{\d+\}', line):
+            logger.debug("(detected ad) %s" % line.encode("ascii", errors="ignore"))
+            if not re.match(r"^\{\d+\}\{\d+\}", line):
                 garbage = True
                 buffer = []
             continue
 
         buffer.append(line)
 
-    if cleaned_lines[0] == '':
+    if cleaned_lines[0] == "":
         cleaned_lines.pop(0)
 
-    return '\n'.join(cleaned_lines)
+    return "\n".join(cleaned_lines)
 
-def open_file_wrapper(file, mode='r', encoding='utf-8'):
+
+def open_file_wrapper(file, mode="r", encoding="utf-8"):
     if py2:
         return lambda: open(file, mode)
     return lambda: open(file, mode, encoding=encoding)
 
+
 def get_json(path, filename):
     path = path if os.path.isdir(path) else os.path.dirname(path)
-    if not filename.endswith('.json'):
-        filename += '.json'
+    if not filename.endswith(".json"):
+        filename += ".json"
 
     json_path = os.path.join(path, filename)
-    with open_file_wrapper(json_path)() as json_result:
-        return json.load(json_result)
+    try:
+        with open_file_wrapper(json_path)() as json_result:
+            return json.load(json_result)
+    except JSONDecodeError as e:
+        logger.error("Failed to decode JSON file %s: %s" % (json_path, e))
+        return None
 
-def find_file_in_archive(core, namelist, exts, episode_number=''):
+
+def find_file_in_archive(core, namelist, exts, episode_number=""):
     first_ext_match = None
     exact_file = None
     for file in namelist:
@@ -184,11 +230,12 @@ def find_file_in_archive(core, namelist, exts, episode_number=''):
             sub_meta = extract_season_episode(file_lower, True)
             if not first_ext_match:
                 first_ext_match = file
-            if (episode_number == '' or sub_meta.episode == episode_number):
+            if episode_number == "" or sub_meta.episode == episode_number:
                 exact_file = file
                 break
 
     return exact_file if exact_file is not None else first_ext_match
+
 
 def get_zipfile_namelist(zipfile):
     infolist = zipfile.infolist()
@@ -201,10 +248,13 @@ def get_zipfile_namelist(zipfile):
         for info in infolist:
             filename = info.filename
             if not info.flag_bits & zip_utf8_flag:
-                filename = info.filename.encode(py3_zip_missing_utf8_flag_fallback_encoding).decode(default_encoding)
+                filename = info.filename.encode(
+                    py3_zip_missing_utf8_flag_fallback_encoding
+                ).decode(default_encoding)
             namelist.append(filename)
 
     return namelist
+
 
 def extract_zipfile_member(zipfile, filename, dest):
     if py2:
@@ -212,16 +262,22 @@ def extract_zipfile_member(zipfile, filename, dest):
     else:
         try:
             return zipfile.extract(filename, dest)
-        except:
-            filename = filename.encode(default_encoding).decode(py3_zip_missing_utf8_flag_fallback_encoding)
+        except UnicodeEncodeError as e:
+            logger.error("Unicode error extracting %s: %s" % (filename, e))
+            filename = filename.encode(default_encoding).decode(
+                py3_zip_missing_utf8_flag_fallback_encoding
+            )
             return zipfile.extract(filename, dest)
 
+
 def extract_season_episode(filename, episode_fallback=False, zfill=3):
-    episode_pattern = r'(?:e|ep.?|episode.?)(\d{1,5})(?:v\d?)?'
-    season_pattern = r'(?:s|season.?)(\d{1,5})'
-    combined_pattern = r'\b(?:s|season)(\d{1,5})\s?[x|\-|\_|\s]\s?[a-z]?(\d{1,5})(?:v\d?)?\b'
-    range_episodes_pattern = r'\b(?:.{1,4}e|ep|eps|episodes|\s)?(\d{1,5}?)(?:v.?)?\s?[\-|\~]\s?(\d{1,5})(?:v.?)?\b'
-    date_pattern = r'\b(\d{2,4}-\d{1,2}-\d{2,4})\b'
+    episode_pattern = r"(?:e|ep.?|episode.?)(\d{1,5})(?:v\d?)?"
+    season_pattern = r"(?:s|season.?)(\d{1,5})"
+    combined_pattern = (
+        r"\b(?:s|season)(\d{1,5})\s?[x|\-|\_|\s]\s?[a-z]?(\d{1,5})(?:v\d?)?\b"
+    )
+    range_episodes_pattern = r"\b(?:.{1,4}e|ep|eps|episodes|\s)?(\d{1,5}?)(?:v.?)?\s?[\-|\~]\s?(\d{1,5})(?:v.?)?\b"
+    date_pattern = r"\b(\d{2,4}-\d{1,2}-\d{2,4})\b"
 
     filename = re.sub(date_pattern, "", filename)
     season_match = re.search(season_pattern, filename, re.IGNORECASE)
@@ -243,8 +299,10 @@ def extract_season_episode(filename, episode_fallback=False, zfill=3):
 
     if episode_fallback and not episode:
         # If no matches found, attempt to capture episode-like sequences
-        fallback_pattern = re.compile(r'\bE?P?(\d{1,5})v?\d?\b', re.IGNORECASE)
-        filename = re.sub(r'[\s\.\:\;\(\)\[\]\{\}\\\/\&\€\'\`\#\@\=\$\?\!\%\+\-\_\*\^]', " ", filename)
+        fallback_pattern = re.compile(r"\bE?P?(\d{1,5})v?\d?\b", re.IGNORECASE)
+        filename = re.sub(
+            r"[\s\.\:\;\(\)\[\]\{\}\\\/\&\€\'\`\#\@\=\$\?\!\%\+\-\_\*\^]", " ", filename
+        )
         fallback_matches = fallback_pattern.findall(filename)
 
         if fallback_matches:
@@ -255,6 +313,6 @@ def extract_season_episode(filename, episode_fallback=False, zfill=3):
         {
             "season": season.lstrip("0").zfill(zfill) if season else "",
             "episode": episode.lstrip("0").zfill(zfill) if episode else "",
-            "episodes_range": episodes_range
+            "episodes_range": episodes_range,
         }
     )

--- a/a4kSubtitles/service.py
+++ b/a4kSubtitles/service.py
@@ -1,29 +1,30 @@
 # -*- coding: utf-8 -*-
 
+
 def start(api):
     core = api.core
     monitor = core.kodi.xbmc.Monitor()
     has_done_subs_check = False
-    prev_playing_filename = ''
+    prev_playing_filename = ""
 
     while not monitor.abortRequested():
         if monitor.waitForAbort(1):
             break
 
-        if not core.kodi.get_bool_setting('general', 'auto_search'):
+        if not core.kodi.get_bool_setting("general", "auto_search"):
             continue
 
         has_video = core.kodi.xbmc.Player().isPlayingVideo()
 
         if not has_video and has_done_subs_check:
-            prev_playing_filename = ''
+            prev_playing_filename = ""
             has_done_subs_check = False
 
-        has_video_duration = core.kodi.xbmc.getCondVisibility('Player.HasDuration')
+        has_video_duration = core.kodi.xbmc.getCondVisibility("Player.HasDuration")
 
         # In-case episode changed.
         if has_video:
-            playing_filename = core.kodi.xbmc.getInfoLabel('Player.Filenameandpath')
+            playing_filename = core.kodi.xbmc.getInfoLabel("Player.Filenameandpath")
             if prev_playing_filename != playing_filename:
                 has_done_subs_check = False
                 prev_playing_filename = playing_filename
@@ -34,106 +35,140 @@ def start(api):
         has_done_subs_check = True
         has_subtitles = False
 
-        preferredlang = core.kodi.get_kodi_setting('locale.subtitlelanguage')
-        prefer_sdh = core.kodi.get_bool_setting('general', 'prefer_sdh')
-        prefer_forced = not prefer_sdh and (core.kodi.get_bool_setting('general', 'prefer_forced') or preferredlang == 'forced_only')
+        preferredlang = core.kodi.get_kodi_setting("locale.subtitlelanguage")
+        prefer_sdh = core.kodi.get_bool_setting("general", "prefer_sdh")
+        prefer_forced = not prefer_sdh and (
+            core.kodi.get_bool_setting("general", "prefer_forced")
+            or preferredlang == "forced_only"
+        )
         preferredlang = core.kodi.parse_language(preferredlang)
 
         try:
+
             def update_sub_stream():
-                if not core.kodi.get_bool_setting('general', 'auto_select'):
+                if not core.kodi.get_bool_setting("general", "auto_select"):
                     return
                 if preferredlang is None:
-                    core.logger.debug('no subtitle language found')
+                    core.logger.debug("no subtitle language found")
                     return
 
                 player_props = core.kodi.get_kodi_player_subtitles()
-                preferredlang_code = core.utils.get_lang_id(preferredlang, core.kodi.xbmc.ISO_639_2)
-                sub_langs = [core.utils.get_lang_id(s, core.kodi.xbmc.ISO_639_2) for s in core.kodi.xbmc.Player().getAvailableSubtitleStreams()]
+                preferredlang_code = core.utils.get_lang_id(
+                    preferredlang, core.kodi.xbmc.ISO_639_2
+                )
+                sub_langs = [
+                    core.utils.get_lang_id(s, core.kodi.xbmc.ISO_639_2)
+                    for s in core.kodi.xbmc.Player().getAvailableSubtitleStreams()
+                ]
 
-                preferedlang_sub_indexes = [i for i, s in enumerate(sub_langs) if preferredlang_code == s]
-                core.logger.debug('player_props: %s' % player_props)
-                core.logger.debug('prefer_sdh: %s' % prefer_sdh)
-                core.logger.debug('prefer_forced: %s' % prefer_forced)
-                core.logger.debug('preferredlang_code: %s' % preferredlang_code)
-                core.logger.debug('sub_langs: %s' % sub_langs)
-                core.logger.debug('preferedlang_sub_indexes: %s' % preferedlang_sub_indexes)
+                preferedlang_sub_indexes = [
+                    i for i, s in enumerate(sub_langs) if preferredlang_code == s
+                ]
+                core.logger.debug("player_props: %s" % player_props)
+                core.logger.debug("prefer_sdh: %s" % prefer_sdh)
+                core.logger.debug("prefer_forced: %s" % prefer_forced)
+                core.logger.debug("preferredlang_code: %s" % preferredlang_code)
+                core.logger.debug("sub_langs: %s" % sub_langs)
+                core.logger.debug(
+                    "preferedlang_sub_indexes: %s" % preferedlang_sub_indexes
+                )
 
                 if len(preferedlang_sub_indexes) == 0:
-                    core.logger.debug('no subtitles found for %s' % preferredlang)
+                    core.logger.debug("no subtitles found for %s" % preferredlang)
                     return
 
                 def find_sub_index():
-                    if 'subtitles' not in player_props:
+                    if "subtitles" not in player_props:
                         return None
 
                     sub_index = None
-                    for sub in player_props['subtitles']:
-                        subname = sub['name'].lower()
-                        if sub['language'] != preferredlang_code:
+                    for sub in player_props["subtitles"]:
+                        subname = sub["name"].lower()
+                        if sub["language"] != preferredlang_code:
                             continue
-                        if prefer_sdh and (sub['isimpaired'] or 'sdh' in subname or 'captions' in subname or 'honorific' in subname):
-                            core.logger.debug('found SDH subtitles: %s' % subname)
-                            sub_index = sub['index']
+                        if prefer_sdh and (
+                            sub["isimpaired"]
+                            or "sdh" in subname
+                            or "captions" in subname
+                            or "honorific" in subname
+                        ):
+                            core.logger.debug("found SDH subtitles: %s" % subname)
+                            sub_index = sub["index"]
                             break
-                        if prefer_forced and (sub['isforced'] or 'forced' in subname):
-                            core.logger.debug('found forced subtitles: %s' % subname)
-                            sub_index = sub['index']
+                        if prefer_forced and (sub["isforced"] or "forced" in subname):
+                            core.logger.debug("found forced subtitles: %s" % subname)
+                            sub_index = sub["index"]
                             break
 
                     if sub_index is None:
-                        for sub in player_props['subtitles']:
-                            subname = sub['name'].lower()
-                            if sub['language'] != preferredlang_code:
+                        for sub in player_props["subtitles"]:
+                            subname = sub["name"].lower()
+                            if sub["language"] != preferredlang_code:
                                 continue
-                            if not sub['isforced'] and all(s not in subname for s in ['forced', 'songs', 'commentary']):
-                                core.logger.debug('found default subtitles: %s' % subname)
-                                sub_index = sub['index']
+                            if not sub["isforced"] and all(
+                                s not in subname
+                                for s in ["forced", "songs", "commentary"]
+                            ):
+                                core.logger.debug(
+                                    "found default subtitles: %s" % subname
+                                )
+                                sub_index = sub["index"]
                                 break
 
                     return sub_index
 
                 sub_index = find_sub_index()
-                if sub_index is None and preferredlang_code == 'pob':
-                    core.logger.debug('no subtitles found for %s, trying por' % preferredlang)
-                    preferredlang_code = 'por'
+                if sub_index is None and preferredlang_code == "pob":
+                    core.logger.debug(
+                        "no subtitles found for %s, trying por" % preferredlang
+                    )
+                    preferredlang_code = "por"
                     sub_index = find_sub_index()
 
                 if sub_index is None:
                     if prefer_sdh:
-                        core.logger.debug('no SDH subtitles found for %s, fallback to last index from matched langs' % preferredlang)
+                        core.logger.debug(
+                            "no SDH subtitles found for %s, fallback to last index from matched langs"
+                            % preferredlang
+                        )
                         sub_index = preferedlang_sub_indexes[-1]
                     elif not prefer_forced and len(preferedlang_sub_indexes) > 1:
-                        core.logger.debug('no subtitles found for %s, fallback to second index from matched langs' % preferredlang)
+                        core.logger.debug(
+                            "no subtitles found for %s, fallback to second index from matched langs"
+                            % preferredlang
+                        )
                         sub_index = preferedlang_sub_indexes[1]
                     else:
-                        core.logger.debug('no subtitles found for %s, fallback to first index from matched langs' % preferredlang)
+                        core.logger.debug(
+                            "no subtitles found for %s, fallback to first index from matched langs"
+                            % preferredlang
+                        )
                         sub_index = preferedlang_sub_indexes[0]
 
-                if sub_index != player_props['currentsubtitle']['index']:
+                if sub_index != player_props["currentsubtitle"]["index"]:
                     core.kodi.xbmc.Player().setSubtitleStream(sub_index)
                 return True
 
             has_subtitles = update_sub_stream()
-        except Exception as e:
-            core.logger.debug('Error on update_sub_stream: %s' % e)
+        except (KeyError, TypeError) as e:
+            core.logger.error("Error on update_sub_stream: %s" % e)
 
         if has_subtitles:
             continue
 
-        has_imdb = core.kodi.xbmc.getInfoLabel('VideoPlayer.IMDBNumber')
+        has_imdb = core.kodi.xbmc.getInfoLabel("VideoPlayer.IMDBNumber")
         if not has_imdb:
             continue
 
-        if not core.kodi.get_bool_setting('general', 'auto_download'):
-            core.kodi.xbmc.executebuiltin('ActivateWindow(SubtitleSearch)')
+        if not core.kodi.get_bool_setting("general", "auto_download"):
+            core.kodi.xbmc.executebuiltin("ActivateWindow(SubtitleSearch)")
             continue
 
-        languages = core.kodi.get_kodi_setting('subtitles.languages')
+        languages = core.kodi.get_kodi_setting("subtitles.languages")
         params = {
-            'action': 'search',
-            'languages': ','.join(languages),
-            'preferredlanguage': preferredlang
+            "action": "search",
+            "languages": ",".join(languages),
+            "preferredlanguage": preferredlang,
         }
 
         results = api.search(params)
@@ -142,4 +177,5 @@ def start(api):
                 subfile = api.download(result)
                 core.kodi.xbmc.Player().setSubtitles(subfile)
                 break
-            except: pass
+            except (OSError, RuntimeError) as e:
+                core.logger.error("Failed to download or set subtitles: %s" % e)

--- a/tests/test_kodi.py
+++ b/tests/test_kodi.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+os.environ["A4KSUBTITLES_API_MODE"] = '{"kodi": true}'
+from a4kSubtitles.lib import kodi, logger
+from tests.utils import spy_fn
+
+os.environ.pop("A4KSUBTITLES_API_MODE", None)
+
+
+def test_json_rpc_logs_on_missing_value():
+    default = kodi.xbmc.executeJSONRPC
+    kodi.xbmc.executeJSONRPC = lambda _: '{ "result": {} }'
+    spy = spy_fn(logger, "error")
+
+    result = kodi.json_rpc("Test", {})
+
+    kodi.xbmc.executeJSONRPC = default
+    spy.restore()
+
+    assert result == {}
+    assert spy.call_count == 1

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,57 +2,78 @@
 
 from .common import api, service, utils
 
+
 def __mock_monitor(api):
     monitor = lambda: None
     monitor.__check_num = 1
+
     def __monitor_is_at_least_third_check():
         if monitor.__check_num < 3:
             monitor.__check_num += 1
             return False
         return True
+
     monitor.abortRequested = lambda: __monitor_is_at_least_third_check()
     monitor.waitForAbort = lambda _: False
 
     default = api.core.kodi.xbmc.Monitor
     api.core.kodi.xbmc.Monitor = lambda: monitor
+
     def restore():
         api.core.kodi.xbmc.Monitor = default
+
     return restore
+
 
 def __mock_is_playingvideo(api, mock_playing_state):
     default = api.core.kodi.xbmc.Player().isPlayingVideo
     api.core.kodi.xbmc.Player().isPlayingVideo = lambda: mock_playing_state
+
     def restore():
         api.core.kodi.xbmc.Player().isPlayingVideo = default
+
     return restore
+
 
 def __mock_get_cond_visibility(api, mock_data):
     default = api.core.kodi.xbmc.getCondVisibility
     api.core.kodi.xbmc.getCondVisibility = lambda v: mock_data.get(v, False)
+
     def restore():
         api.core.kodi.xbmc.getCondVisibility = default
+
     return restore
+
 
 def __mock_get_info_label(api, mock_data):
     default = api.core.kodi.xbmc.getInfoLabel
     api.core.kodi.xbmc.getInfoLabel = lambda v: mock_data.get(v, False)
+
     def restore():
         api.core.kodi.xbmc.getInfoLabel = default
+
     return restore
+
 
 def __mock_api_search(api):
     default = api.search
     api.search = lambda p: [{}]
+
     def restore():
         api.search = default
+
     return restore
+
 
 def __mock_api_download(api, result=None):
     default = api.download
     api.download = lambda p: result
+
     def restore():
         api.download = default
+
     return restore
+
 
 def __mock(api, settings):
     restore_monitor = __mock_monitor(api)
@@ -61,16 +82,23 @@ def __mock(api, settings):
     def restore():
         restore_monitor()
         restore_settings()
+
     return restore
+
 
 def test_service_start_when_video_playing():
     def test_playing_video(state):
-        a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+        a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
 
-        restore = __mock(a4ksubtitles_api, {
-            'general.auto_search': 'True',
-        })
-        get_infolabel_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, 'getInfoLabel')
+        restore = __mock(
+            a4ksubtitles_api,
+            {
+                "general.auto_search": "True",
+            },
+        )
+        get_infolabel_spy = utils.spy_fn(
+            a4ksubtitles_api.core.kodi.xbmc, "getInfoLabel"
+        )
         restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, state)
 
         service.start(a4ksubtitles_api)
@@ -84,13 +112,19 @@ def test_service_start_when_video_playing():
     assert test_playing_video(True) != 0
     assert test_playing_video(False) == 0
 
-def test_service_start_when_disabled():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
 
-    restore = __mock(a4ksubtitles_api, {
-        'general.auto_search': 'false',
-    })
-    get_cond_visibility_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, 'getCondVisibility')
+def test_service_start_when_disabled():
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
+
+    restore = __mock(
+        a4ksubtitles_api,
+        {
+            "general.auto_search": "false",
+        },
+    )
+    get_cond_visibility_spy = utils.spy_fn(
+        a4ksubtitles_api.core.kodi.xbmc, "getCondVisibility"
+    )
     restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, True)
 
     service.start(a4ksubtitles_api)
@@ -101,13 +135,19 @@ def test_service_start_when_disabled():
 
     assert get_cond_visibility_spy.call_count == 0
 
-def test_service_start_when_enabled():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
 
-    restore = __mock(a4ksubtitles_api, {
-        'general.auto_search': 'true',
-    })
-    get_cond_visibility_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, 'getCondVisibility')
+def test_service_start_when_enabled():
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
+
+    restore = __mock(
+        a4ksubtitles_api,
+        {
+            "general.auto_search": "true",
+        },
+    )
+    get_cond_visibility_spy = utils.spy_fn(
+        a4ksubtitles_api.core.kodi.xbmc, "getCondVisibility"
+    )
     restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, True)
 
     service.start(a4ksubtitles_api)
@@ -118,23 +158,33 @@ def test_service_start_when_enabled():
 
     assert get_cond_visibility_spy.call_count > 0
 
-def test_service_when_video_does_not_have_subtitles():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
 
-    restore = __mock(a4ksubtitles_api, {
-        'general.auto_search': 'true',
-    })
-    restore_get_cond_visibility = __mock_get_cond_visibility(a4ksubtitles_api, {
-        'Player.HasDuration': True,
-        'VideoPlayer.HasSubtitles': False,
-        'VideoPlayer.SubtitlesEnabled': False,
-    })
-    restore_get_info_label = __mock_get_info_label(a4ksubtitles_api, {
-        'VideoPlayer.IMDBNumber': 'tt1234567',
-    })
+def test_service_when_video_does_not_have_subtitles():
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
+
+    restore = __mock(
+        a4ksubtitles_api,
+        {
+            "general.auto_search": "true",
+        },
+    )
+    restore_get_cond_visibility = __mock_get_cond_visibility(
+        a4ksubtitles_api,
+        {
+            "Player.HasDuration": True,
+            "VideoPlayer.HasSubtitles": False,
+            "VideoPlayer.SubtitlesEnabled": False,
+        },
+    )
+    restore_get_info_label = __mock_get_info_label(
+        a4ksubtitles_api,
+        {
+            "VideoPlayer.IMDBNumber": "tt1234567",
+        },
+    )
     restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, True)
 
-    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, 'executebuiltin')
+    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, "executebuiltin")
 
     service.start(a4ksubtitles_api)
 
@@ -145,24 +195,34 @@ def test_service_when_video_does_not_have_subtitles():
     executebuiltin_spy.restore()
 
     assert executebuiltin_spy.call_count == 1
+
 
 def test_service_when_video_has_disabled_subtitles():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
 
-    restore = __mock(a4ksubtitles_api, {
-        'general.auto_search': 'true',
-    })
-    restore_get_cond_visibility = __mock_get_cond_visibility(a4ksubtitles_api, {
-        'Player.HasDuration': True,
-        'VideoPlayer.HasSubtitles': True,
-        'VideoPlayer.SubtitlesEnabled': False,
-    })
-    restore_get_info_label = __mock_get_info_label(a4ksubtitles_api, {
-        'VideoPlayer.IMDBNumber': 'tt1234567',
-    })
+    restore = __mock(
+        a4ksubtitles_api,
+        {
+            "general.auto_search": "true",
+        },
+    )
+    restore_get_cond_visibility = __mock_get_cond_visibility(
+        a4ksubtitles_api,
+        {
+            "Player.HasDuration": True,
+            "VideoPlayer.HasSubtitles": True,
+            "VideoPlayer.SubtitlesEnabled": False,
+        },
+    )
+    restore_get_info_label = __mock_get_info_label(
+        a4ksubtitles_api,
+        {
+            "VideoPlayer.IMDBNumber": "tt1234567",
+        },
+    )
     restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, True)
 
-    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, 'executebuiltin')
+    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, "executebuiltin")
 
     service.start(a4ksubtitles_api)
 
@@ -174,23 +234,33 @@ def test_service_when_video_has_disabled_subtitles():
 
     assert executebuiltin_spy.call_count == 1
 
-def test_service_when_does_not_have_video_duration():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
 
-    restore = __mock(a4ksubtitles_api, {
-        'general.auto_search': 'true',
-    })
-    restore_get_cond_visibility = __mock_get_cond_visibility(a4ksubtitles_api, {
-        'Player.HasDuration': False,
-        'VideoPlayer.HasSubtitles': False,
-        'VideoPlayer.SubtitlesEnabled': False,
-    })
-    restore_get_info_label = __mock_get_info_label(a4ksubtitles_api, {
-        'VideoPlayer.IMDBNumber': 'tt1234567',
-    })
+def test_service_when_does_not_have_video_duration():
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
+
+    restore = __mock(
+        a4ksubtitles_api,
+        {
+            "general.auto_search": "true",
+        },
+    )
+    restore_get_cond_visibility = __mock_get_cond_visibility(
+        a4ksubtitles_api,
+        {
+            "Player.HasDuration": False,
+            "VideoPlayer.HasSubtitles": False,
+            "VideoPlayer.SubtitlesEnabled": False,
+        },
+    )
+    restore_get_info_label = __mock_get_info_label(
+        a4ksubtitles_api,
+        {
+            "VideoPlayer.IMDBNumber": "tt1234567",
+        },
+    )
     restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, True)
 
-    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, 'executebuiltin')
+    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, "executebuiltin")
 
     service.start(a4ksubtitles_api)
 
@@ -202,28 +272,42 @@ def test_service_when_does_not_have_video_duration():
 
     assert executebuiltin_spy.call_count == 0
 
-def test_service_auto_download():
-    a4ksubtitles_api = api.A4kSubtitlesApi({'kodi': True})
 
-    restore = __mock(a4ksubtitles_api, {
-        'general.auto_search': 'true',
-        'general.auto_download': 'true',
-    })
-    restore_get_cond_visibility = __mock_get_cond_visibility(a4ksubtitles_api, {
-        'Player.HasDuration': True,
-        'VideoPlayer.HasSubtitles': False,
-        'VideoPlayer.SubtitlesEnabled': False,
-    })
-    restore_get_info_label = __mock_get_info_label(a4ksubtitles_api, {
-        'VideoPlayer.IMDBNumber': 'tt1234567',
-    })
+def test_service_auto_download():
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
+
+    restore = __mock(
+        a4ksubtitles_api,
+        {
+            "general.auto_search": "true",
+            "general.auto_download": "true",
+        },
+    )
+    restore_get_cond_visibility = __mock_get_cond_visibility(
+        a4ksubtitles_api,
+        {
+            "Player.HasDuration": True,
+            "VideoPlayer.HasSubtitles": False,
+            "VideoPlayer.SubtitlesEnabled": False,
+        },
+    )
+    restore_get_info_label = __mock_get_info_label(
+        a4ksubtitles_api,
+        {
+            "VideoPlayer.IMDBNumber": "tt1234567",
+        },
+    )
     restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, True)
     restore_api_search = __mock_api_search(a4ksubtitles_api)
-    expected_download_result = 'test_download_result'
-    restore_api_download = __mock_api_download(a4ksubtitles_api, expected_download_result)
+    expected_download_result = "test_download_result"
+    restore_api_download = __mock_api_download(
+        a4ksubtitles_api, expected_download_result
+    )
 
-    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, 'executebuiltin')
-    setsubtitles_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc.Player(), 'setSubtitles')
+    executebuiltin_spy = utils.spy_fn(a4ksubtitles_api.core.kodi.xbmc, "executebuiltin")
+    setsubtitles_spy = utils.spy_fn(
+        a4ksubtitles_api.core.kodi.xbmc.Player(), "setSubtitles"
+    )
 
     service.start(a4ksubtitles_api)
 
@@ -238,3 +322,55 @@ def test_service_auto_download():
     assert executebuiltin_spy.call_count == 0
     assert setsubtitles_spy.call_count == 1
     setsubtitles_spy.called_with(expected_download_result)
+
+
+def test_service_download_error_is_logged():
+    a4ksubtitles_api = api.A4kSubtitlesApi({"kodi": True})
+
+    restore = __mock(
+        a4ksubtitles_api,
+        {
+            "general.auto_search": "true",
+            "general.auto_download": "true",
+        },
+    )
+    restore_get_cond_visibility = __mock_get_cond_visibility(
+        a4ksubtitles_api,
+        {
+            "Player.HasDuration": True,
+            "VideoPlayer.HasSubtitles": False,
+            "VideoPlayer.SubtitlesEnabled": False,
+        },
+    )
+    restore_get_info_label = __mock_get_info_label(
+        a4ksubtitles_api,
+        {
+            "VideoPlayer.IMDBNumber": "tt1234567",
+        },
+    )
+    restore_isplayingvideo = __mock_is_playingvideo(a4ksubtitles_api, True)
+    restore_api_search = __mock_api_search(a4ksubtitles_api)
+
+    default_download = a4ksubtitles_api.download
+
+    def raise_oserror(_):
+        raise OSError("download failed")
+
+    a4ksubtitles_api.download = raise_oserror
+
+    def restore_api_download():
+        a4ksubtitles_api.download = default_download
+
+    logger_spy = utils.spy_fn(a4ksubtitles_api.core.logger, "error")
+
+    service.start(a4ksubtitles_api)
+
+    restore()
+    restore_isplayingvideo()
+    restore_get_cond_visibility()
+    restore_get_info_label()
+    restore_api_search()
+    restore_api_download()
+    logger_spy.restore()
+
+    assert logger_spy.call_count == 1

--- a/tests/test_utils_json.py
+++ b/tests/test_utils_json.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import json
+
+from a4kSubtitles.lib import logger, utils
+from tests.utils import spy_fn
+
+
+def test_get_json_logs_on_invalid_json(tmp_path):
+    invalid = tmp_path / "data.json"
+    invalid.write_text("{ invalid", encoding="utf-8")
+
+    spy = spy_fn(logger, "error")
+    result = utils.get_json(str(tmp_path), "data.json")
+    spy.restore()
+
+    assert result is None
+    assert spy.call_count >= 1
+
+
+def test_get_json_returns_data_on_valid_json(tmp_path):
+    data = {"key": "value"}
+    valid = tmp_path / "data.json"
+    valid.write_text(json.dumps(data), encoding="utf-8")
+
+    result = utils.get_json(str(tmp_path), "data.json")
+
+    assert result == data

--- a/tests/test_utils_lang.py
+++ b/tests/test_utils_lang.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from a4kSubtitles.lib import kodi, logger, utils
+from tests.utils import spy_fn
+
+
+def test_get_lang_id_logs_on_invalid_language():
+    spy = spy_fn(logger, "error")
+    result = utils.get_lang_id("notalanguage", kodi.xbmc.ISO_639_2)
+    spy.restore()
+
+    assert result == ""
+    assert spy.call_count >= 1


### PR DESCRIPTION
## Summary
- replace broad except clauses with specific exceptions in service, kodi, and utils
- add logging for handled errors
- add tests for JSON-RPC, language parsing, service download failures, and JSON loader error handling

## Testing
- `pre-commit run --files a4kSubtitles/lib/utils.py tests/test_utils_json.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4e47da58832fab2ba3ec64a2e321